### PR TITLE
Support only building partial documentation: administrate section

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,11 @@ BUILDDIR      = build
 docs:
 	docker run --rm -v $$(pwd):/mnt $(DOCKER_USER)/$(DOCKER_IMAGE):$(DOCKER_TAG) make clean html
 
+# Only build part of the documentation
+# See 'exclude_patterns' in source/conf.py
+docs-administrate:
+	docker run --rm -e SPHINXOPTS='-t administrate' -v $$(pwd):/mnt $(DOCKER_USER)/$(DOCKER_IMAGE):$(DOCKER_TAG) make clean html
+
 exec:
 	docker run -it -v $$(pwd):/mnt $(DOCKER_USER)/$(DOCKER_IMAGE):$(DOCKER_TAG)
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -40,7 +40,8 @@ master_doc = 'index'
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
-
+if tags.has('administrate'):
+    exclude_patterns = ['**/*single*/**', '**/*install*/**', 'understand/**']
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
Allows to run `make docs-administrate`, which produces a partial documentation (in this case: only the pages from the how-to/administrate dir). This can be useful when sending documentation pages to someone.

## Checklist:

Please tick the following before making your PR:

* [x] After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.
