### PR TITLE
Add local dev mode without docker as dependency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+#  http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+
+[Makefile]
+indent_style = tab
+indent_size = tab
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 build
+.venv
 
 # Vim temporary files
 *.swp
-
-

--- a/Makefile
+++ b/Makefile
@@ -19,14 +19,18 @@ VENV_DIR = $(MKFILE_DIR)/.venv
 VENV_BIN = $(VENV_DIR)/bin
 
 
+.PHONY: Makefile
+
+
+.DEFAULT: docs
 .PHONY: docs
 docs:
-	docker run --rm -v $(MKFILE_DIR):/mnt $(DOCKER_USER)/$(DOCKER_IMAGE):$(DOCKER_TAG) make html
+	docker run --rm -v $$(pwd):/mnt $(DOCKER_USER)/$(DOCKER_IMAGE):$(DOCKER_TAG) make clean html
 
 # Only build part of the documentation
 # See 'exclude_patterns' in source/conf.py
 docs-administrate:
-	docker run --rm -e SPHINXOPTS='-t administrate' -v $(MKFILE_DIR):/mnt $(DOCKER_USER)/$(DOCKER_IMAGE):$(DOCKER_TAG) make html
+	docker run --rm -e SPHINXOPTS='-t administrate' -v $$(pwd):/mnt $(DOCKER_USER)/$(DOCKER_IMAGE):$(DOCKER_TAG) make clean html
 	cd build && zip -r administration-wire-$$(date +"%Y-%m-%d").zip html
 
 .PHONY: exec
@@ -57,13 +61,17 @@ dev-run:
 		$(SPHINXOPTS) \
 		"$(SOURCEDIR)" "$(BUILDDIR)"
 
+.PHONY: dev-build
+dev-build: export PATH := $(VENV_BIN):$(PATH)
+dev-build:
+	make clean html
+
 .PHONY: help
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-# Catch-all target: route all unknown targets to Sphinx using the new
-# "make mode" option. This "converts" unknown targets into sub-commands of
-# the $(SPHINXBUILD) CLI. $(O) is meant as a shortcut for $(SPHINXOPTS).
-.PHONY: Makefile
-%: Makefile
+# Catch-all target: route all unknown targets to Sphinx. This "converts" unknown targets into sub-commands (or more precicly
+# into `buildername`) of the $(SPHINXBUILD) CLI (see https://www.gnu.org/software/make/manual/html_node/Last-Resort.html).
+# $(O) is meant as a shortcut for $(SPHINXOPTS).
+%:
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+SHELL = bash
+
+.DEFAULT_GOAL := docs
+
+MKFILE_DIR = $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
+
 DOCKER_USER   ?= quay.io/wire
 DOCKER_IMAGE  = alpine-sphinx
 DOCKER_TAG    ?= latest
@@ -6,34 +12,58 @@ DOCKER_TAG    ?= latest
 # from the environment for the first two.
 SPHINXOPTS    ?= -q
 SPHINXBUILD   ?= sphinx-build
-SOURCEDIR     = src
-BUILDDIR      = build
+SOURCEDIR     = $(MKFILE_DIR)/src
+BUILDDIR      = $(MKFILE_DIR)/build
 
-.PHONY: help Makefile push docker docs exec
+VENV_DIR = $(MKFILE_DIR)/.venv
+VENV_BIN = $(VENV_DIR)/bin
 
+
+.PHONY: docs
 docs:
-	docker run --rm -v $$(pwd):/mnt $(DOCKER_USER)/$(DOCKER_IMAGE):$(DOCKER_TAG) make clean html
+	docker run --rm -v $(MKFILE_DIR):/mnt $(DOCKER_USER)/$(DOCKER_IMAGE):$(DOCKER_TAG) make html
 
 # Only build part of the documentation
 # See 'exclude_patterns' in source/conf.py
 docs-administrate:
-	docker run --rm -e SPHINXOPTS='-t administrate' -v $$(pwd):/mnt $(DOCKER_USER)/$(DOCKER_IMAGE):$(DOCKER_TAG) make clean html
+	docker run --rm -e SPHINXOPTS='-t administrate' -v $(MKFILE_DIR):/mnt $(DOCKER_USER)/$(DOCKER_IMAGE):$(DOCKER_TAG) make html
 	cd build && zip -r administration-wire-$$(date +"%Y-%m-%d").zip html
 
+.PHONY: exec
 exec:
-	docker run -it -v $$(pwd):/mnt $(DOCKER_USER)/$(DOCKER_IMAGE):$(DOCKER_TAG)
+	docker run -it -v $(MKFILE_DIR):/mnt $(DOCKER_USER)/$(DOCKER_IMAGE):$(DOCKER_TAG)
 
+.PHONY: docker
 docker:
-	docker build -t $(DOCKER_USER)/$(DOCKER_IMAGE):$(DOCKER_TAG) .
+	docker build -t $(DOCKER_USER)/$(DOCKER_IMAGE):$(DOCKER_TAG) $(MKFILE_DIR)
 
+.PHONY: push
 push:
-	aws s3 sync build/html s3://origin-docs.wire.com/
+	aws s3 sync $(BUILDDIR)/html s3://origin-docs.wire.com/
 
+.PHONY: dev-install
+dev-install:
+	python3 -m venv --copies --clear $(VENV_DIR)
+	$(VENV_BIN)/pip3 install sphinx sphinx-autobuild recommonmark
+
+.PHONY: dev-run
+dev-run: export PATH := $(VENV_BIN):$(PATH)
+dev-run:
+	rm -rf "$(BUILDDIR)"
+	sphinx-autobuild \
+		--port 3000 \
+		--host 127.0.0.1 \
+		-b html \
+		$(SPHINXOPTS) \
+		"$(SOURCEDIR)" "$(BUILDDIR)"
+
+.PHONY: help
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option. This "converts" unknown targets into sub-commands of
 # the $(SPHINXBUILD) CLI. $(O) is meant as a shortcut for $(SPHINXOPTS).
+.PHONY: Makefile
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Generate docs (using docker, so you don't need to install python dependencies yo
 make
 ```
 
-(Alternatively, if you have python dependencies installed, run `make html`).
+You can also install the dependencies (requires `python3`) locally with `make dev-install` and
+enter a *development mode* by executing `make dev-srun` to start a local server and file watcher.
+Alternatively, if you already have all python dependencies installed globally, run `make html`.
 
 Look at results by opening build/html/index.html
 


### PR DESCRIPTION
* `dev-install` allows to install dependencies for a local development mode by utilizing python's `venv` module
* `dev-run` starts a local web server and file watcher
* mention this approach to make it more visible for other contributors
* add editorconfig to ensure tags in makefiles across IDEs
* remove `clean` target since it's neither defined nor is it a sphinx builder
* refactor Makefile to use absolute (relative to the Makefile) paths and applied some best practice (.PHONY right next to the target)
