### PR TITLE
with 4 cores there will be an error installing wire-server

### DIFF
--- a/src/how-to/install/kubernetes.rst
+++ b/src/how-to/install/kubernetes.rst
@@ -8,7 +8,7 @@ Installing kubernetes for a demo installation (on a single virtual machine)
 How to set up your hosts.ini file
 -------------------------------------
 
-Assuming a single virtual machine with a public IP address running Ubuntu 16.04 or 18.04, with at least 4 CPU cores and at least 8 GB of memory.
+Assuming a single virtual machine with a public IP address running Ubuntu 16.04 or 18.04, with at least 5 CPU cores and at least 8 GB of memory.
 
 From ``wire-server-deploy/ansible``:
 


### PR DESCRIPTION
with 4 cores I was running into trouble starting all the kubernetes in wire-server

## Checklist:

Please tick the following before making your PR:

* [x ] I ran `make` on this branch to build the docs and there are **no WARNINGs**.
* [ x] After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.
