### PR TITLE
deeplink.rst: Removed superfluous dot

### DIFF
--- a/src/how-to/associate/deeplink.rst
+++ b/src/how-to/associate/deeplink.rst
@@ -58,7 +58,7 @@ Otherwise you need to create a ``.json`` file, and host it somewhere users can g
 
 There is no requirement for these hosts to be consistent, e.g. the REST endpoint could be `wireapp.pineapple.com` and the team setting `teams.banana.com`. If you have been following this documentation closely, these hosts will likely be consistent in naming, regardless.
 
-You now need to get a link referring to that ``..json`` file to your users, prepended with ``wire://access/?config=``. For example, you can save the above ``.json`` file as ``https://example.com/wire.json``, and save the following HTML content as ``https://example.com/wire.html``:
+You now need to get a link referring to that ``.json`` file to your users, prepended with ``wire://access/?config=``. For example, you can save the above ``.json`` file as ``https://example.com/wire.json``, and save the following HTML content as ``https://example.com/wire.html``:
 
 .. code:: html
 


### PR DESCRIPTION
This PR only changes a small punctuation hiccup. For consistency, only one dot is needed.

## Checklist:

Please tick the following before making your PR:

* [x] I ran `make` on this branch to build the docs and there are is only one warning that is not related to my change:
``src/how-to/install/includes/helm_dns-ingress-troubleshooting.inc.rst:134: WARNING: duplicate label helm_prod_troubleshooting, other instance in /mnt/src/how-to/install/helm.rst``

* [x] After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.
