### PR TITLE
Explain that all keys in the deeplink need to be set

### DIFF
--- a/src/how-to/associate/deeplink.rst
+++ b/src/how-to/associate/deeplink.rst
@@ -56,6 +56,8 @@ Otherwise you need to create a ``.json`` file, and host it somewhere users can g
       "title" : "Production"
    }
 
+**IMPORTANT NOTE:** Clients require **ALL** keys to be present in the JSON file; if some of these keys are irrelevant to your installation (e.g., you don't have a websiteURL) you can leave these values as indicated in the above example.
+
 There is no requirement for these hosts to be consistent, e.g. the REST endpoint could be `wireapp.pineapple.com` and the team setting `teams.banana.com`. If you have been following this documentation closely, these hosts will likely be consistent in naming, regardless.
 
 You now need to get a link referring to that ``.json`` file to your users, prepended with ``wire://access/?config=``. For example, you can save the above ``.json`` file as ``https://example.com/wire.json``, and save the following HTML content as ``https://example.com/wire.html``:


### PR DESCRIPTION
A customer spent a fair amount trying to debug this: turned out they had some missing keys in the JSON file

## Checklist:

Please tick the following before making your PR:

* [x] I ran `make` on this branch to build the docs and there are **no WARNINGs**.
* [x] After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.
