### PR TITLE
docs: update to use the nix/container-provided ansible and helm.

### DIFF
--- a/src/how-to/install/ansible-VMs.rst
+++ b/src/how-to/install/ansible-VMs.rst
@@ -106,7 +106,7 @@ To install kubernetes:
 
 From ``wire-server-deploy/ansible``::
 
-   poetry run ansible-playbook -i hosts.ini kubernetes.yml -vv
+   ansible-playbook -i hosts.ini kubernetes.yml -vv
 
 When the playbook finishes correctly (which can take up to 20 minutes), you should have a folder ``artifacts`` containing a file ``admin.conf``. Copy this file::
 
@@ -155,7 +155,7 @@ for a full list of variables to change if necessary)
 
 ::
 
-   poetry run ansible-playbook -i hosts.ini cassandra.yml -vv
+   ansible-playbook -i hosts.ini cassandra.yml -vv
 
 ElasticSearch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -183,7 +183,7 @@ ElasticSearch
 
 ::
 
-   poetry run ansible-playbook -i hosts.ini elasticsearch.yml -vv
+   ansible-playbook -i hosts.ini elasticsearch.yml -vv
 
 Minio
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -223,7 +223,7 @@ this step.
 
 ::
 
-   poetry run ansible-playbook -i hosts.ini minio.yml -vv
+   ansible-playbook -i hosts.ini minio.yml -vv
 
 Restund
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -269,7 +269,7 @@ Install restund:
 
 ::
 
-   poetry run ansible-playbook -i hosts.ini restund.yml -vv
+   ansible-playbook -i hosts.ini restund.yml -vv
 
 IMPORTANT checks
 ^^^^^^^^^^^^^^^^
@@ -278,7 +278,7 @@ IMPORTANT checks
 
 ::
 
-   poetry run ansible-playbook -i hosts.ini cassandra-verify-ntp.yml -vv
+   ansible-playbook -i hosts.ini cassandra-verify-ntp.yml -vv
 
 Installing helm charts - prerequisites
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -306,7 +306,7 @@ In your hosts.ini under ``[all:vars]``:
 
 - Now run the helm_external.yml playbook, to populate network values for helm:
 
-   poetry run ansible-playbook -i hosts.ini -vv --diff helm_external.yml
+   ansible-playbook -i hosts.ini -vv --diff helm_external.yml
 
 You can now can install the helm charts.
 

--- a/src/how-to/install/ansible-dependencies.rst
+++ b/src/how-to/install/ansible-dependencies.rst
@@ -27,7 +27,7 @@ See `how to install docker <https://docker.com>`__. Then:
    # alternatively: create a key pair exclusively for this installation
    ssh-keygen -t ed25519 -a 100 -f ../dot_ssh/id_ed25519
    ssh-add ../dot_ssh/id_ed25519
-   # make sure the server accepts your ssh key for user root
+   # Copy your SSH key to the hosts you are going to deploy wire onto
    ssh-copy-id -i ../dot_ssh/id_ed25519.pub root@<server>
 
    docker run -it --network=host -v $(pwd):/mnt -v $(pwd)/../dot_ssh:/root/.ssh -v $(pwd)/../dot_kube:/root/.kube quay.io/wire/wire-server-deploy-deps:latest

--- a/src/how-to/install/ansible-dependencies.rst
+++ b/src/how-to/install/ansible-dependencies.rst
@@ -61,7 +61,7 @@ To connect to a running container for a second shell:
 Use Nix and Direnv to provide dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We use a custom version of `ansible` (with some additional python
+We use a specific version of `ansible` (with some additional python
 dependencies), a specific version of `terraform`, `helm`, `kubectl`, `gnumake`
 and some more tooling.
 

--- a/src/how-to/install/ansible-dependencies.rst
+++ b/src/how-to/install/ansible-dependencies.rst
@@ -11,7 +11,7 @@ Use the provided Docker container
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 On your machine, you need to have `docker` installed (or any other compatible
-runtime really, even though instructions may differ).
+container runtime. Instructions may need to be modified accordingly).
 
 See `how to install docker <https://docker.com>`__. Then:
 

--- a/src/how-to/install/ansible-dependencies.rst
+++ b/src/how-to/install/ansible-dependencies.rst
@@ -74,16 +74,12 @@ the instructions above.
 Download external Ansible Roles
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We use git submodules to manage some external ansible roles.
+We use git submodules to manage external ansible roles.
 
 We recommend setting `git config --global submodule.recurse true` and `git
-config --global fetch.parallel 10` for convenience.
+config --global fetch.parallel 10`, so they're automatically fetched for
+convenience.
 
-If you've already cloned this repo before having enabled this, run `git
-submodule update --init --recursive` once (or if you don't want to enable this,
-manually on every update).
-
-We currently also still need to download some external ansible roles manually
-using `ansible-galaxy`.
-
-This is exposed as a `Makefile` target via `make download-ansible-roles-force`.
+If you've already cloned this repo before having enabled this, or don't want to
+enable this, run `git submodule update --init --recursive` once (and every time
+in the future you update the repo).

--- a/src/how-to/install/ansible-dependencies.rst
+++ b/src/how-to/install/ansible-dependencies.rst
@@ -28,7 +28,7 @@ See `how to install docker <https://docker.com>`__. Then:
    ssh-keygen -t ed25519 -a 100 -f ../dot_ssh/id_ed25519
    ssh-add ../dot_ssh/id_ed25519
    # Copy your SSH key to the hosts you are going to deploy wire onto
-   ssh-copy-id -i ../dot_ssh/id_ed25519.pub root@<server>
+   ssh-copy-id -i ../dot_ssh/id_ed25519.pub <user>@<server>
 
    docker run -it --network=host -v $(pwd):/mnt -v $(pwd)/../dot_ssh:/root/.ssh -v $(pwd)/../dot_kube:/root/.kube quay.io/wire/wire-server-deploy-deps:latest
    # inside the container, copy everything to the mounted host file system:

--- a/src/how-to/install/ansible-dependencies.rst
+++ b/src/how-to/install/ansible-dependencies.rst
@@ -10,7 +10,7 @@ If you don't intend to develop *on the tooling itself*, you should use this.
 Use the provided Docker container
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-On your machine, you need to have `docker` installed (or any other Container
+On your machine, you need to have `docker` installed (or any other compatible
 runtime really, even though instructions may differ).
 
 See `how to install docker <https://docker.com>`__. Then:

--- a/src/how-to/install/ansible-tinc.rst
+++ b/src/how-to/install/ansible-tinc.rst
@@ -51,4 +51,4 @@ Configure the physical network interface inside tinc.yml if it is not
 
 ::
 
-   poetry run ansible-playbook -i hosts.ini tinc.yml -vv
+   ansible-playbook -i hosts.ini tinc.yml -vv

--- a/src/how-to/install/helm-prod.rst
+++ b/src/how-to/install/helm-prod.rst
@@ -64,15 +64,13 @@ In case ``kubectl version`` shows both Client and Server versions, but ``helm ve
 
 Upgrading from Helm2 to Helm3
 -----------------------------
-Because of it's better support of offline environments, we prefer to use Helm3. This step is optional, but recommended for offline deployments.
+Because of its better support of offline environments, we strongly encourage
+you to use Helm 3.
 
-Download and install the newest version of Helm 3 from get.helm.sh.
+It is already provided in the `quay.io/wire/wire-server-deploy-deps` image.
 
-.. code:: shell
-
-   curl https://get.helm.sh/helm-v3.1.0-linux-amd64.tar.gz -o helm-v3.1.0-linux-amd64.tar.gz
-   tar -xzf helm-v3.1.0-linux-amd64.tar.gz --strip=1 --wildcards */helm
-   sudo cp helm /usr/local/bin/
+If you really need to use an older version of helm, please manually download a
+static binary from their website and add it to your `$PATH`.
 
 How to download charts for Helm 3 in an offline environment
 -----------------------------------------------------------
@@ -157,11 +155,11 @@ If you are using minio instead of AWS S3, you should also run:
 .. code:: shell
 
    helm upgrade --install minio-external wire/minio-external -f values/minio-external/values.yaml --wait
-   
+
 How to install fake AWS services for SNS / SQS / DynamoDB
 ---------------------------------------------------------
 AWS SNS is required to send notifications to clients. If you use the fake-aws version, clients will use the websocket method to receive notifications, which keeps connections to the servers open, draining battery.
-AWS SES and SQS are used for mail delivery, and reception, respectively. 
+AWS SES and SQS are used for mail delivery, and reception, respectively.
 
 
 Open a terminal and run:

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -9,6 +9,10 @@ installed (or any other compatible container runtime really, even though
 instructions may need to be modified). See [how to install
 docker](https://docker.com) for instructions.
 
+On ubuntu 18.04, connected to the internet:
+
+apt install docker.io
+
 Create a fresh workspace to download the artifacts:
 
 ```
@@ -322,5 +326,4 @@ d helm upgrade sftd ./charts/sftd \
   --set-file tls.crt=/path/to/tls.crt \
   --set-file tls.key=/path/to/tls.key
 ```
-
 

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -13,6 +13,8 @@ On ubuntu 18.04, connected to the internet:
 
 apt install docker.io
 
+Ensure the user you are using for the install has permission to run docker, or add 'sudo' to the docker commands below.
+
 Create a fresh workspace to download the artifacts:
 
 ```
@@ -326,4 +328,3 @@ d helm upgrade sftd ./charts/sftd \
   --set-file tls.crt=/path/to/tls.crt \
   --set-file tls.key=/path/to/tls.key
 ```
-

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -193,6 +193,22 @@ d helm install nginx-ingress-controller ./charts/nginx-ingress-controller
 d helm install nginx-ingress-services ./charts/nginx-ingress-services --values ./values/nginx-ingress-services/values.yaml  --values ./values/nginx-ingress-services/secrets.yaml
 ```
 
+### Ephemeral Helm deployment
+
+Before applying the HElm charts, adjust your own copy of `wire-server/values.yaml` so that every `replicaCount` is set to `1`. Futhermore, change every occurrence of `[cassandra,elasticsearch]-external` to `[cassandra,elasticsearch]-ehemeral` and `minio-external` to `fake-aws-s3`.
+
+```
+d helm install databases-ephemeral ./charts/databases-ephemeral
+d helm install fake-aws ./charts/fake-aws
+d helm install reaper ./charts/reaper
+d helm install demo-smtp ./charts/demo-smtp
+
+d helm install wire-server ./charts/wire-server --timeout=15m0s --values ./values/wire-server/values.yaml --values ./values/wire-server/secrets.yaml
+
+d helm install nginx-ingress-controller ./charts/nginx-ingress-controller
+d helm install nginx-ingress-services ./charts/nginx-ingress-services --values ./values/nginx-ingress-services/values.yaml  --values ./values/nginx-ingress-services/secrets.yaml
+```
+
 ## Deploying legalhold
 Legalhold is an optional component that can be installed on-prem for
 compliance. The following steps explain how to enable it.

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -169,7 +169,7 @@ TODO: add commands to verify things are good
 
 Afterwards, run the following playbook to create helm values
 ```
-dapi ansible/helm_external.yaml
+dapi ansible/helm_external.yml
 ```
 
 Write other values by copying over TODO

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -104,8 +104,11 @@ The following artifacts are provided:
 
 Provide a `ansible/inventory/offline/hosts.ini` configured to your environment.
 Copy over `hosts.ini.example`  to `hosts.ini`, and edit it, following the instructions in that file.
-Don't forget to set a value for `restund_zrest_secret`, in case that is part of your inventory.
 
+In case that is part of your inventory, don't forget to set a value for `restund_zrest_secret`:
+```
+tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 42 | head -n 1
+```
 
 Also, take a look at `ansible/inventory/offline/group_vars/all/offline.yml` to
 see if it matches your expectations.

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -110,7 +110,7 @@ Also, take a look at `ansible/inventory/offline/group_vars/all/offline.yml` to
 see if it matches your expectations.
 
 
-Copy over binaries and debs, serves assets from the asset host, and configures
+Copy over binaries and debs, serves assets from the asset host, and configure
 other hosts to fetch debs from it:
 
 

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -159,7 +159,7 @@ Now, deploy all other services which don't run in kubernetes:
 ```
 dapi ansible/restund.yml
 dapi ansible/cassandra.yml
-dapi ansible/elasticsearch.yaml
+dapi ansible/elasticsearch.yml
 dapi ansible/minio.yaml
 ```
 TODO: add commands to verify things are good

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -29,7 +29,7 @@ ssh-keygen -t ed25519 -a 100 -f ./dot_ssh/id_ed25519
 ssh-add ./dot_ssh/id_ed25519
 ````
 
-Ensure the nodes your deploying to, as well as the bastion host accept this ssh key for user `root`:
+Ensure the nodes your deploying to, as well as any bastion host between you and them accept this ssh key for the user you are performing the install as:
 
 ```
 # make sure the server accepts your ssh key for user root

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -158,7 +158,7 @@ Now, deploy all other services which don't run in kubernetes:
 
 ```
 dapi ansible/restund.yml
-dapi ansible/cassandra.yaml
+dapi ansible/cassandra.yml
 dapi ansible/elasticsearch.yaml
 dapi ansible/minio.yaml
 ```

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -43,7 +43,7 @@ vs.
 ssh-add ./assets/dot_ssh/id_ed25519
 ```
 
-Ensure the nodes your deploying to, as well as any bastion host between you and them accept this ssh key for the user you are performing the install as:
+Ensure the nodes you are deploying to, as well as any bastion host between you and them accept this ssh key for the user you are performing the install as:
 
 ```
 # make sure the server accepts your ssh key for user root
@@ -89,7 +89,7 @@ The following artifacts are provided:
    These are the container images our charts (and charts we depend on) refer to.
    Also come as tarballs, and are seeded like the system containers.
  - *containers-other*
-   These are other container images, not deployed inside k8s. Currently only
+   These are other container images, not deployed inside k8s. Currently, only
    contains restund.
  - `debs`
    This acts as a self-contained dump of all packages required to install
@@ -174,7 +174,7 @@ dapi ansible/helm_external.yml
 
 Write other values by copying over TODO
 
-Use Helm to apply the varios charts in order to install the Wire platform
+Use Helm to apply the various charts in order to install the Wire platform
 
 TODO: update https://docs.wire.com/how-to/install/helm-prod.html to not add the iptables hack
 
@@ -231,7 +231,7 @@ d helm install local-path-provisioner ./charts/local-path-provisioner --set stor
 
 ### Install the legalhold helm chart
 In `values/wire-server/values.yaml` make sure that `tags.legalhold` is set to `true`.
-Also make sure that `FEATURE_ENABLE_LEGAL_HOLD: "true"` is set.  Then set
+Also, make sure that `FEATURE_ENABLE_LEGAL_HOLD: "true"` is set.  Then set
 ```
 legalhold:
   host: "legalhold.example.com"
@@ -249,7 +249,7 @@ Now, get a certificate for the domain you set in `legalhold.host` and add this
 to `values/wire-server/secrets.yaml`.  These are the `legalhold.tlsKey` and
 `legalhold.tlsCert` options.
 
-Finally in `values/wire-server/secrets.yaml`, `legalhold.serviceToken`  needs to
+Finally, in `values/wire-server/secrets.yaml`, `legalhold.serviceToken`  needs to
 be set to a random alpha-numerical string.
 
 
@@ -267,7 +267,7 @@ Extract the public key out of the legalhold certificate:
 openssl x509 -pubkey -noout -in cert.pem  > pubkey.pem
 ```
 
-Go to your team-setings page at `https://teams.<your-domain>`. In the Settings page you can configure
+Go to your team-settings page at `https://teams.<your-domain>`. In the Settings page you can configure
 the legalhold service. Paste in the public key and the service token (that you configured under `legalhold.serviceToken`) to configure the legalhold service.
 
 

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -104,6 +104,7 @@ The following artifacts are provided:
 
 Provide a `ansible/inventory/offline/hosts.ini` configured to your environment.
 Copy over `hosts.ini.example`  to `hosts.ini`, and edit it, following the instructions in that file.
+Don't forget to set a value for `restund_zrest_secret`, in case that is part of your inventory.
 
 
 Also, take a look at `ansible/inventory/offline/group_vars/all/offline.yml` to

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -160,7 +160,7 @@ Now, deploy all other services which don't run in kubernetes:
 dapi ansible/restund.yml
 dapi ansible/cassandra.yml
 dapi ansible/elasticsearch.yml
-dapi ansible/minio.yaml
+dapi ansible/minio.yml
 ```
 TODO: add commands to verify things are good
 

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -39,7 +39,6 @@ cp ~/.ssh/id_rsa ./assets/dot_ssh/
 
 vs.
 
-```
 ssh-keygen -t ed25519 -a 100 -f ./assets/dot_ssh/id_ed25519
 ssh-add ./assets/dot_ssh/id_ed25519
 ````

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -147,7 +147,7 @@ Copy over the kubeconfig from one master node:
 d ansible -i ./ansible/inventory/offline/hosts.ini "kube-master[0]" -m fetch -a  "src=/root/.kube/config dest=ansible/kubeconfig flat=yes"
 ```
 
-Ensure the cluster comes up healthy. Copy TODO kubecfg from a master node, and put it to TODO. The container also contains kubectl, so check the node status:
+Ensure the cluster comes up healthy. The container also contains kubectl, so check the node status:
 
 ```
 d kubectl get nodes -owide

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -23,7 +23,7 @@ the URL of the "assets" tarball linked from CI.
 Extract the above listed artifacts into your workspace:
 
 ```
-wget https://s3-eu-west-1.amazonaws.com/public.wire.com/artifacts/wire-server-deploy-static-4a8bd3e21a078b378dcc577861947c04a180f976.tgz
+wget https://s3-eu-west-1.amazonaws.com/public.wire.com/artifacts/wire-server-deploy-static-<HASH>.tgz
 tar xvzf wire-server-deploy-static-77a1abdce68f77d6dd2ac53192825c6ac46c0aa0.tgz
 ```
 

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -66,7 +66,7 @@ There's also a docker image containing the tooling inside this repo.
 If you don't intend to develop *on wire-server-deploy itself*, you should load
 this and register an alias:
 ```
-docker load -i ./containers-other/pxllp20fzzbafc179v4yjqijx9zw0254-docker-image-wire-server-deploy.tar.gz
+docker load -i ./containers-other/*-docker-image-wire-server-deploy.tar.gz
 alias d="docker run -it --network=host -v $PWD:/wire-server-deploy quay.io/wire/wire-server-deploy:pxllp20fzzbafc179v4yjqijx9zw0254"
 alias dapi="d ansible-playbook -i ansible/inventory/offline/hosts.ini --private-key ./dot_ssh/id_ed25519"
 ```

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -157,7 +157,7 @@ They should all report ready.
 Now, deploy all other services which don't run in kubernetes:
 
 ```
-dapi ansible/restund.yaml
+dapi ansible/restund.yml
 dapi ansible/cassandra.yaml
 dapi ansible/elasticsearch.yaml
 dapi ansible/minio.yaml

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -26,6 +26,7 @@ Extract the above listed artifacts into your workspace:
 wget https://s3-eu-west-1.amazonaws.com/public.wire.com/artifacts/wire-server-deploy-static-<HASH>.tgz
 tar xvzf wire-server-deploy-static-<HASH>.tgz
 ```
+Where the HASH above is the hash of your deployment artifact, given to you by Wire, or acquired by looking at the above build job.
 
 You should now have a directory named `assets` containing the offline deploy artifacts.
 

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -23,7 +23,7 @@ the URL of the "assets" tarball linked from CI.
 Extract the above listed artifacts into your workspace:
 
 ```
-wget https://s3-eu-west-1.amazonaws.com/public.wire.com/artifacts/wire-server-deploy-static-77a1abdce68f77d6dd2ac53192825c6ac46c0aa0.tgz
+wget https://s3-eu-west-1.amazonaws.com/public.wire.com/artifacts/wire-server-deploy-static-4a8bd3e21a078b378dcc577861947c04a180f976.tgz
 tar xvzf wire-server-deploy-static-77a1abdce68f77d6dd2ac53192825c6ac46c0aa0.tgz
 ```
 

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -34,7 +34,7 @@ Ensure the nodes your deploying to, as well as any bastion host between you and 
 ```
 # make sure the server accepts your ssh key for user root
 # TODO: replace with ansible oneliner making use of the inventory
-ssh-copy-id -i ./dot_ssh/id_ed25519.pub root@<server>
+ssh-copy-id -i ./dot_ssh/id_ed25519.pub <username>@<server>
 ```
 
 Obtain the latest artifacts from wire-server-deploy. Once

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -101,7 +101,7 @@ The following artifacts are provided:
 Provide a `ansible/inventory/offline/hosts.ini` configured to your environment.
 Copy over `hosts.ini.example`  to `hosts.ini`, and edit it, following the instructions in that file.
 
-Also, take a look at `ansible/inventory/offline/group_vars/all//offline.yml` to
+Also, take a look at `ansible/inventory/offline/group_vars/all/offline.yml` to
 see if it matches your expectations.
 
 

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -292,3 +292,30 @@ TODO:
 
  - run other playbooks for other pets.
  - add zauth tool to our docker container
+
+### Installing sftd
+
+For full docs with details and explanations please see https://github.com/wireapp/wire-server-deploy/blob/d7a089c1563089d9842aa0e6be4a99f6340985f2/charts/sftd/README.md
+
+First, make sure you have a certificate for `sftd.<yourdomain>`. This could be the same wildcard or SAN certificate
+you used at previous steps.
+
+Next, make sure that in your `hosts.ini` you have annotated all the nodes that are able to run sftd workloads correctly.
+It is important for sftd to be aware of its own external IP.
+E.g.:
+```
+kubenode3 node_labels="wire.com/role=sftd" node_annotations="{'wire.com/external-ip': 'XXXX'}"
+```
+
+Now, deploy the chart. Note the `nodeSelector` matching up with your ansible inventory!!
+
+```
+d helm upgrade sftd ./charts/sftd \
+  --set 'nodeSelector.wire\.com/role=sftd' \
+  --set host=sftd.example.com \
+  --set allowOrigin=https://webapp.example.com \
+  --set-file tls.crt=/path/to/tls.crt \
+  --set-file tls.key=/path/to/tls.key
+```
+
+

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -39,7 +39,6 @@ cp ~/.ssh/id_rsa ./assets/dot_ssh/
 
 vs.
 
-ssh-keygen -t ed25519 -a 100 -f ./assets/dot_ssh/id_ed25519
 ssh-add ./assets/dot_ssh/id_ed25519
 ````
 

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -15,28 +15,6 @@ Create a fresh workspace to download the artifacts:
 cd ...  # you pick a good location!
 ```
 
-Copy over ssh keys, or generate a key pair exclusively for this installation:
-
-```
-mkdir -p ./dot_ssh
-cp ~/.ssh/id_rsa ./dot_ssh/
-```
-
-vs.
-
-```
-ssh-keygen -t ed25519 -a 100 -f ./dot_ssh/id_ed25519
-ssh-add ./dot_ssh/id_ed25519
-````
-
-Ensure the nodes your deploying to, as well as any bastion host between you and them accept this ssh key for the user you are performing the install as:
-
-```
-# make sure the server accepts your ssh key for user root
-# TODO: replace with ansible oneliner making use of the inventory
-ssh-copy-id -i ./dot_ssh/id_ed25519.pub <username>@<server>
-```
-
 Obtain the latest artifacts from wire-server-deploy. Once
 https://github.com/wireapp/wire-server-deploy/pull/363 is finished, these will
 be in the "Releases" tab. Until then, go to the PRs "Checks" tab, and look for
@@ -45,24 +23,51 @@ the URL of the "assets" tarball linked from CI.
 Extract the above listed artifacts into your workspace:
 
 ```
-wget https://path.of.the/artifact.tgz
-tar xvzf path-to-file.tgz
+wget https://s3-eu-west-1.amazonaws.com/public.wire.com/artifacts/wire-server-deploy-static-77a1abdce68f77d6dd2ac53192825c6ac46c0aa0.tgz
+tar xvzf wire-server-deploy-static-77a1abdce68f77d6dd2ac53192825c6ac46c0aa0.tgz
 ```
+
+You should now have a directory named `assets` containing the offline deploy artifacts.
+
+
+Copy over ssh keys, or generate a key pair exclusively for this installation:
+
+```
+mkdir -p ./assets/dot_ssh
+cp ~/.ssh/id_rsa ./assets/dot_ssh/
+```
+
+vs.
+
+```
+ssh-keygen -t ed25519 -a 100 -f ./assets/dot_ssh/id_ed25519
+ssh-add ./assets/dot_ssh/id_ed25519
+````
+
+Ensure the nodes your deploying to, as well as any bastion host between you and them accept this ssh key for the user you are performing the install as:
+
+```
+# make sure the server accepts your ssh key for user root
+# TODO: replace with ansible oneliner making use of the inventory
+ssh-copy-id -i ./assets/dot_ssh/id_ed25519.pub <username>@<server>
+```
+
+Now `cd ./assets`. All the following operations should happen from the `assets` directory
+
 
 There's also a docker image containing the tooling inside this repo.
 
 If you don't intend to develop *on wire-server-deploy itself*, you should load
 this and register an alias:
-
 ```
-docker load -i assets/wire-server-deploy-*.tar
-alias d="docker run -it --network=host -v $PWD:/wire-server-deploy quay.io/wire/wire-server-deploy:$wire_server_deploy_version"
+docker load -i ./containers-other/6wxaqfjbkpr02yrx6vjkc13abjcdqv8q-docker-image-wire-server-deploy.tar.gz
+alias d="docker run -it --network=host -v $PWD:/wire-server-deploy quay.io/wire/wire-server-deploy:6wxaqfjbkpr02yrx6vjkc13abjcdqv8q"
 alias dapi="d ansible-playbook -i ansible/inventory/offline/hosts.ini"
 ```
 
 The following artifacts are provided:
 
- - `wire-server-deploy-*.tar`
+ - `containers-other/wire-server-deploy-*.tar`
    A container image containing ansible, helm, and other tools and their
    dependencies in versions verified to be compatible with the current wire
    stack. Published to `quay.io/wire/wire-server-deploy` as well, but shipped
@@ -100,6 +105,7 @@ The following artifacts are provided:
 
 Provide a `ansible/inventory/offline/hosts.ini` configured to your environment.
 Copy over `hosts.ini.example`  to `hosts.ini`, and edit it, following the instructions in that file.
+
 
 Also, take a look at `ansible/inventory/offline/group_vars/all/offline.yml` to
 see if it matches your expectations.

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -307,6 +307,11 @@ E.g.:
 kubenode3 node_labels="wire.com/role=sftd" node_annotations="{'wire.com/external-ip': 'XXXX'}"
 ```
 
+If these weren't already set; you should rerun :
+```
+dapi ansible/kubernetes.yml --skip-tags bootstrap-os,preinstall,container-engine
+```
+
 Now, deploy the chart. Note the `nodeSelector` matching up with your ansible inventory!!
 
 ```

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -174,9 +174,24 @@ dapi ansible/helm_external.yml
 
 Write other values by copying over TODO
 
+Use Helm to apply the varios charts in order to install the Wire platform
+
+```
+d helm install cassandra-external ./charts/cassandra-external --values ./values/cassandra-external/values.yaml
+d helm install elasticsearch-external ./charts/elasticsearch-external --values ./values/elasticsearch-external/values.yaml
+d helm install minio-external ./charts/minio-external --values ./values/minio-external/values.yaml
+d helm install fake-aws ./charts/fake-aws --values ./values/fake-aws/values.yaml
+d helm install demo-smtp ./charts/demo-smtp --values ./values/demo-smtp/values.yaml
+d helm install redis-ephemeral ./charts/nginx-ingress-controller
+d helm install reaper ./charts/reaper
+
+d helm install wire-server ./charts/wire-server --timeout=15m0s --values ./values/wire-server/values.yaml --values ./values/wire-server/secrets.yaml
+
+d helm install nginx-ingress-controller ./charts/nginx-ingress-controller
+d helm install nginx-ingress-services ./charts/nginx-ingress-services --values ./values/nginx-ingress-services/values.yaml  --values ./values/nginx-ingress-services/secrets.yaml
+```
+
 TODO:
 
  - run other playbooks for other pets.
- - run `helm_external.yml` to render helm values from the ansible inventory
- - run helm to install our charts
  - add zauth tool to our docker container

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -321,7 +321,7 @@ dapi ansible/kubernetes.yml --skip-tags bootstrap-os,preinstall,container-engine
 Now, deploy the chart. Note the `nodeSelector` matching up with your ansible inventory!!
 
 ```
-d helm upgrade sftd ./charts/sftd \
+d helm upgrade --install sftd ./charts/sftd \
   --set 'nodeSelector.wire\.com/role=sftd' \
   --set host=sftd.example.com \
   --set allowOrigin=https://webapp.example.com \

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -99,7 +99,7 @@ The following artifacts are provided:
    environment.
 
 Provide a `ansible/inventory/offline/hosts.ini` configured to your environment.
-Copy over `hosts.ini.example` from that same folder.
+Copy over `hosts.ini.example`  to `hosts.ini`, and edit it, following the instructions in that file.
 
 Also, take a look at `ansible/inventory/offline/group_vars/all//offline.yml` to
 see if it matches your expectations.

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -1,0 +1,139 @@
+# How to install wire
+
+We have a pipeline in  `wire-server-deploy` producing container images, static
+binaries, ansible playbooks, debian package sources and everything required to
+install Wire.
+
+On your machine (we call this the "admin host"), you need to have `docker`
+installed (or any other compatible container runtime really, even though
+instructions may need to be modified). See [how to install
+docker](https://docker.com) for instructions.
+
+Create a fresh workspace to download the artifacts:
+
+```
+cd ...  # you pick a good location!
+```
+
+Copy over ssh keys, or generate a key pair exclusively for this installation:
+
+```
+mkdir -p ./dot_ssh
+cp ~/.ssh/id_rsa ./dot_ssh/
+```
+
+vs.
+
+```
+ssh-keygen -t ed25519 -a 100 -f ./dot_ssh/id_ed25519
+ssh-add ./dot_ssh/id_ed25519
+````
+
+Ensure the nodes your deploying to, as well as the bastion host accept this ssh key for user `root`:
+
+```
+# make sure the server accepts your ssh key for user root
+# TODO: replace with ansible oneliner making use of the inventory
+ssh-copy-id -i ./dot_ssh/id_ed25519.pub root@<server>
+```
+
+Obtain the latest artifacts from wire-server-deploy. Once
+https://github.com/wireapp/wire-server-deploy/pull/363 is finished, these will
+be in the "Releases" tab. Until then, go to the PRs "Checks" tab, and look for
+the URL of the "assets" tarball linked from CI.
+
+Extract the above listed artifacts into your workspace:
+
+```
+wget https://path.of.the/artifact.tgz
+tar xvzf path-to-file.tgz
+```
+
+There's also a docker image containing the tooling inside this repo.
+
+If you don't intend to develop *on wire-server-deploy itself*, you should load
+this and register an alias:
+
+```
+docker load -i assets/wire-server-deploy-*.tar
+alias d="docker run -it --network=host -v $PWD:/wire-server-deploy quay.io/wire/wire-server-deploy:$wire_server_deploy_version"
+alias dapi="d ansible-playbook -i ansible/inventory/offline/hosts.ini"
+```
+
+The following artifacts are provided:
+
+ - `wire-server-deploy-*.tar`
+   A container image containing ansible, helm, and other tools and their
+   dependencies in versions verified to be compatible with the current wire
+   stack. Published to `quay.io/wire/wire-server-deploy` as well, but shipped
+   in the artifacts tarball for convenience.
+ - `ansible`
+   These contain all the ansible playbooks the rest of the guide refers to, as
+   well as an example inventory, which should be configured according to the
+   environment this is installed into.
+ - `binaries`
+   This contains static binaries, both used during the kubespray-based
+   kubernetes bootstrapping, as well as to provide some binaries that are
+   installed during other ansible playbook runs.
+ - `charts`
+   The charts themselves, as tarballs. We don't use an external helm
+   repository, every helm chart dependency is resolved already.
+ - `containers-system`
+   These are the container images needed to bootstrap kubernetes itself
+   (currently using kubespray)
+ - `containers-helm`
+   These are the container images our charts (and charts we depend on) refer to.
+   Also come as tarballs, and are seeded like the system containers.
+ - *containers-other*
+   These are other container images, not deployed inside k8s. Currently only
+   contains restund.
+ - `debs`
+   This acts as a self-contained dump of all packages required to install
+   kubespray, as well as all other packages that are installed by ansible
+   playbooks on nodes that don't run kubernetes.
+   There's an ansible playbook copying these assets to an "assethost", starting
+   a little webserver there serving it, and configuring all nodes to use it as
+   a package repo.
+ - `values`
+   Contains helm chart values and secrets. Needs to be tweaked to the
+   environment.
+
+Provide a `ansible/inventory/offline/hosts.ini` configured to your environment.
+Copy over `hosts.ini.example` from that same folder.
+
+Also, take a look at `ansible/inventory/offline/group_vars/all//offline.yml` to
+see if it matches your expectations.
+
+
+Copy over binaries and debs, serves assets from the asset host, and configures
+other hosts to fetch debs from it:
+
+
+```
+dapi ansible/setup-offline-sources.yml
+```
+
+Run kubespray until docker is installed and runs:
+
+```
+dapi ansible/roles-external/kubespray/cluster.yml --tags bastion,bootstrap-os,preinstall,container-engine
+```
+
+With docker being installed, seed all container images:
+
+```
+dapi ansible/seed-offline-docker.yml
+```
+
+Run the rest of kubespray:
+
+```
+dapi ansible/kubernetes.yml --skip-tags bootstrap-os,preinstall,container-engine
+```
+
+TODO:
+
+ - run other playbooks for other pets.
+ - run `helm_external.yml` to render helm values from the ansible inventory
+ - run helm to install our charts
+ - add zauth tool to our docker container

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -24,7 +24,7 @@ Extract the above listed artifacts into your workspace:
 
 ```
 wget https://s3-eu-west-1.amazonaws.com/public.wire.com/artifacts/wire-server-deploy-static-<HASH>.tgz
-tar xvzf wire-server-deploy-static-77a1abdce68f77d6dd2ac53192825c6ac46c0aa0.tgz
+tar xvzf wire-server-deploy-static-<HASH>.tgz
 ```
 
 You should now have a directory named `assets` containing the offline deploy artifacts.

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -67,7 +67,7 @@ If you don't intend to develop *on wire-server-deploy itself*, you should load
 this and register an alias:
 ```
 docker load -i ./containers-other/*-docker-image-wire-server-deploy.tar.gz
-alias d="docker run -it --network=host -v $PWD:/wire-server-deploy quay.io/wire/wire-server-deploy:pxllp20fzzbafc179v4yjqijx9zw0254"
+alias d="docker run -it --network=host -v $PWD:/wire-server-deploy quay.io/wire/wire-server-deploy:<container_ID>"
 alias dapi="d ansible-playbook -i ansible/inventory/offline/hosts.ini --private-key ./dot_ssh/id_ed25519"
 ```
 

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -39,8 +39,9 @@ cp ~/.ssh/id_rsa ./assets/dot_ssh/
 
 vs.
 
+```
 ssh-add ./assets/dot_ssh/id_ed25519
-````
+```
 
 Ensure the nodes your deploying to, as well as any bastion host between you and them accept this ssh key for the user you are performing the install as:
 

--- a/src/how-to/install/installation.md
+++ b/src/how-to/install/installation.md
@@ -191,7 +191,7 @@ d helm install elasticsearch-external ./charts/elasticsearch-external --values .
 d helm install minio-external ./charts/minio-external --values ./values/minio-external/values.yaml
 d helm install fake-aws ./charts/fake-aws --values ./values/fake-aws/values.yaml
 d helm install demo-smtp ./charts/demo-smtp --values ./values/demo-smtp/values.yaml
-d helm install redis-ephemeral ./charts/nginx-ingress-controller
+d helm install redis-ephemeral ./charts/redis-ephemeral
 d helm install reaper ./charts/reaper
 
 d helm install wire-server ./charts/wire-server --timeout=15m0s --values ./values/wire-server/values.yaml --values ./values/wire-server/secrets.yaml

--- a/src/how-to/install/kubernetes.rst
+++ b/src/how-to/install/kubernetes.rst
@@ -27,7 +27,7 @@ How to install kubernetes
 
 From ``wire-server-deploy/ansible``::
 
-   poetry run ansible-playbook -i hosts.ini kubernetes.yml -vv
+   ansible-playbook -i hosts.ini kubernetes.yml -vv
 
 When the playbook finishes correctly (which can take up to 20 minutes), you should have a folder ``artifacts`` containing a file ``admin.conf``. Copy this file::
 


### PR DESCRIPTION
This updates the docs after https://github.com/wireapp/wire-server-deploy/pull/363.

## TODOs
* [ ] Move the currently up-to-date docs from [wsd](https://github.com/wireapp/wire-server-deploy/tree/develop/offline/docs.md) into this PR

## Checklist:

Please tick the following before making your PR:

* [ ] I ran `make` on this branch to build the docs and there are **no WARNINGs**.
* [ ] After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.
