### PR TITLE
[admin:k8s] Add information on how to restart machines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,16 @@ SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = $(MKFILE_DIR)/src
 BUILDDIR      = $(MKFILE_DIR)/build
 # note: if you're using direnv/nix, this will be set to USE_POETRY=0 automatically in .envrc
-USE_POETRY    ?= 1
+USE_POETRY    ?= 0
+
+LOCAL_DIR            = $(MKFILE_DIR)/.local
+BIN_DIR              = $(LOCAL_DIR)/bin
+TEMP_DIR             = $(LOCAL_DIR)/tmp
+PYTHON_INTERPRETER	?= python3
+VENV_DIR             = $(LOCAL_DIR)/venv
+VENV_BIN             = $(LOCAL_DIR)/venv/bin
+POETRY_LOCK          = $(MKFILE_DIR)/poetry.lock
+export PATH := $(VENV_BIN):$(BIN_DIR):$(PATH)
 
 ifeq ($(OS), darwin)
 OPEN := open
@@ -68,6 +77,20 @@ ifeq ($(USE_POETRY), 1)
 else
 	aws s3 sync $(BUILDDIR)/html s3://origin-docs.wire.com/
 endif
+
+
+.PHONY: dev-install
+dev-install: $(VENV_BIN)/sphinx-autobuil
+$(VENV_BIN)/sphinx-autobuil: export POETRY_CACHE_DIR = $(LOCAL_DIR)/poetry/cache
+$(VENV_BIN)/sphinx-autobuil: export POETRY_VIRTUALENVS_CREATE = false
+$(VENV_BIN)/sphinx-autobuil: $(POETRY_LOCK)
+	rm -rf $(LOCAL_DIR)
+	$(PYTHON_INTERPRETER) -m venv $(VENV_DIR)
+	$(VENV_BIN)/pip install poetry
+	# Ubuntu bug, see https://stackoverflow.com/questions/7446187/no-module-named-pkg-resources
+	$(VENV_BIN)/pip install setuptools
+	poetry install
+
 
 .PHONY: dev-run
 dev-run: clean

--- a/src/how-to/administrate/etcd.rst
+++ b/src/how-to/administrate/etcd.rst
@@ -43,6 +43,8 @@ How to inspect tables and data manually
     TODO
 
 
+.. _how-to-rolling-restart-an-etcd-cluster:
+
 How to rolling-restart an etcd cluster
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -82,7 +84,10 @@ Now to perform a rolling restart of the cluster, do the following steps:
 5. Wait for your cluster to be healthy again.
 6. Do the same on the next server.
 
+*For more details and commands, please refer to the official documentation:* `Replacing a failed etcd member <https://kubernetes.io/docs/tasks/administer-cluster/configure-upgrade-etcd/#replacing-a-failed-etcd-member>`__
 
+
+.. _etcd_backup-and-restore:
 
 Backing up and restoring
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -94,6 +99,8 @@ Luckily, etcd can take periodic snapshots of your cluster and these can be used
 in cases of disaster recovery. Information about how to do snapshots and
 restores can be found here:
 https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/recovery.md
+
+*For more details and commands, please refer to the official documentation:* `Backing up an etcd cluster <https://kubernetes.io/docs/tasks/administer-cluster/configure-upgrade-etcd/#backing-up-an-etcd-cluster>`__
 
 
 Troubleshooting

--- a/src/how-to/administrate/etcd.rst
+++ b/src/how-to/administrate/etcd.rst
@@ -84,7 +84,7 @@ Now to perform a rolling restart of the cluster, do the following steps:
 5. Wait for your cluster to be healthy again.
 6. Do the same on the next server.
 
-*For more details and commands, please refer to the official documentation:* `Replacing a failed etcd member <https://kubernetes.io/docs/tasks/administer-cluster/configure-upgrade-etcd/#replacing-a-failed-etcd-member>`__
+*For more details please refer to the official documentation:* `Replacing a failed etcd member <https://kubernetes.io/docs/tasks/administer-cluster/configure-upgrade-etcd/#replacing-a-failed-etcd-member>`__
 
 
 .. _etcd_backup-and-restore:
@@ -100,7 +100,7 @@ in cases of disaster recovery. Information about how to do snapshots and
 restores can be found here:
 https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/recovery.md
 
-*For more details and commands, please refer to the official documentation:* `Backing up an etcd cluster <https://kubernetes.io/docs/tasks/administer-cluster/configure-upgrade-etcd/#backing-up-an-etcd-cluster>`__
+*For more details please refer to the official documentation:* `Backing up an etcd cluster <https://kubernetes.io/docs/tasks/administer-cluster/configure-upgrade-etcd/#backing-up-an-etcd-cluster>`__
 
 
 Troubleshooting

--- a/src/how-to/administrate/kubernetes/index.rst
+++ b/src/how-to/administrate/kubernetes/index.rst
@@ -1,10 +1,21 @@
 Kubernetes
 ==========
 
+.. note::
+
+    These are not the official documentations you are looking for.
+    `This way <https://kubernetes.io/docs/tasks/administer-cluster/>`__ please.
+
+    The content referred below merely contains either some deviation from upstream or
+    additional information enriched here and there with shortcuts to the official documentation.
+
+
 .. toctree::
     :maxdepth: 1
     :glob:
 
     Certificate renewal <certificate-renewal/index.rst>
+    How to restart a machine that is part of a Kubernetes cluster? <restart-machines/index.rst>
+    How to upgrade Kubernetes? <upgrade-cluster/index.rst>
 
 ..

--- a/src/how-to/administrate/kubernetes/restart-machines/index.rst
+++ b/src/how-to/administrate/kubernetes/restart-machines/index.rst
@@ -1,0 +1,45 @@
+.. _restarting-a-machine-in-a-kubernetes-cluster:
+
+Restarting a machine in a Kubernetes cluster
+============================================
+
+.. note::
+
+    1. Know which kind of machine is going to be restarted
+
+        a) control plane (api-server, controllers, etc.)
+        b) node (runs actual workload, e.g. *Brig* or *Webapp*)
+        c) *a* and *b* combined
+
+    2. The kind of machine in question must be deployed redundantly
+    3. Take out machines in a rolling fashion (sequentially, one at a time)
+
+
+Control plane
+~~~~~~~~~~~~~
+
+Depending on whether *etcd* is hosted on the same machine alongside the control plane (common practise), you need
+to take its implications into account (see :ref:`How to rolling-restart an etcd cluster <how-to-rolling-restart-an-etcd-cluster>`)
+when restarting a machine.
+
+Regardless of where *etcd* is located, before turning off any machine that is part of the control plane, one should
+:ref:`back up the cluster state <etcd_backup-and-restore>`.
+
+If a part of the control plane does not run sufficiently redundant, it is advised to prevent any mutating interaction
+during the procedure, until the cluster is healthy again.
+
+.. code:: bash
+
+    kubectl get nodes
+
+
+Node
+~~~~
+
+.. rubric:: High-level steps:
+
+1. Drain the node so that all workload is rescheduled on other nodes
+2. Restart / Update / Decommission
+3. Mark the node as being schedulable again (if not decommissioned)
+
+*For more details and commands, please refer to the official documentation:* `Safely Drain a Node <https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/>`__

--- a/src/how-to/administrate/kubernetes/restart-machines/index.rst
+++ b/src/how-to/administrate/kubernetes/restart-machines/index.rst
@@ -42,4 +42,4 @@ Node
 2. Restart / Update / Decommission
 3. Mark the node as being schedulable again (if not decommissioned)
 
-*For more details and commands, please refer to the official documentation:* `Safely Drain a Node <https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/>`__
+*For more details please refer to the official documentation:* `Safely Drain a Node <https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/>`__

--- a/src/how-to/administrate/kubernetes/upgrade-cluster/index.rst
+++ b/src/how-to/administrate/kubernetes/upgrade-cluster/index.rst
@@ -1,0 +1,82 @@
+Upgrading a Kubernetes cluster
+==============================
+
+Before upgrading Kubernetes, a couple of aspects should be taken into account:
+
+* downtime is (not) permitted
+* stateful backing services run outside or on top of Kubernetes
+
+As a result the following questions arise:
+
+1. Is an in-place upgrade required (reuse existing machines) or is it possible to
+   deploy a second cluster right next to the first one and install Wire on top?
+2. How was the Kubernetes cluster being deployed?
+
+Depending on the deployment method, the upgrade procedure may vary. It may be reasonable to test
+the upgrade in a non-production environment first.
+Regardless of the deployment method, it is recommended to :ref:`back up the cluster state
+<etcd_backup-and-restore>` before starting to upgrade the cluster. Additional background knowledge
+can be found in the section about :ref:`restarting a machine in an kubernetes cluster <restarting-a-machine-in-a-kubernetes-cluster>`.
+
+
+.. warning::
+
+    For an in-place upgrade, it is *NOT* recommended to go straight to the latest Kubernetes
+    version. Instead, one should upgrade step by step to each minor version.
+
+
+Manually
+~~~~~~~~
+
+Doing an upgrade by hand is cumbersome and error-prone, which is why there are tools and
+automation for this procedure. The high-level steps would be:
+
+1. control plane (also see a more detailed `list <https://kubernetes.io/docs/tasks/administer-cluster/cluster-upgrade/#manual-deployments>`__)
+    a) all *etcd* instances
+    b) api-server on each control-plane host
+    c) controllers, scheduler,
+2. nodes (order may vary, depending on whether the kube-components run in containers)
+    * kubelet
+    * kube-proxy
+    * container runtime
+3. clients (``kubectl``, e.g. on workstations or in pipelines)
+
+*For more details, please refer to the official documentation:*
+`Upgrade A Cluster <https://kubernetes.io/docs/tasks/administer-cluster/cluster-upgrade/>`__
+
+
+Kubespray (Ansible)
+~~~~~~~~~~~~~~~~~~~
+
+Kubespray comes with a dedicated playbook that should be used to perform the upgrade:
+``upgrade-cluster.yml``. Before running the playbook, make sure that the right Kubespray version
+is being used. Each Kubespray version supports only a small and sliding window of Kubernetes
+versions (check ``kube_version`` & ``kube_version_min_required`` in ``roles/kubespray-defaults/defaults/main.yaml``
+for a given `release version tag <https://github.com/kubernetes-sigs/kubespray/releases>`__).
+
+The commands may look similar to this example (assuming Kubernetes v1.18 version installed
+with Kubespray 2.14):
+
+.. code:: bash
+
+    git clone https://github.com/kubernetes-sigs/kubespray
+    cd kubespray
+    git checkout release-2.15
+    ${EDITOR} roles/kubespray-defaults/defaults/main.yaml
+
+    ansible-playbook -i ./../path/my/inventory-dir -e kube_version=v1.19.7 ./upgrade-cluster.yml
+
+.. TODO: adjust the example showing how to run this with wire-server-deploy a/o the offline toolchain container image
+.. TODO: add ref to the part of this documentation that talks about the air-gapped installation
+
+Kubespray takes care of bringing the new binaries into position on each machine, restarting
+the components, and draining/uncordon nodes.
+
+*For more details and commands, please refer to the official documentation:*
+`Upgrading Kubernetes in Kubespray <https://kubespray.io/#/docs/upgrades>`__
+
+
+Kubeadm
+~~~~~~~
+
+Please refer to the *official documentation:* `Upgrading kubeadm clusters <https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/>`__

--- a/src/how-to/administrate/kubernetes/upgrade-cluster/index.rst
+++ b/src/how-to/administrate/kubernetes/upgrade-cluster/index.rst
@@ -4,13 +4,13 @@ Upgrading a Kubernetes cluster
 Before upgrading Kubernetes, a couple of aspects should be taken into account:
 
 * downtime is (not) permitted
-* stateful backing services run outside or on top of Kubernetes
+* stateful backing services that run outside or on top of Kubernetes
 
 As a result the following questions arise:
 
 1. Is an in-place upgrade required (reuse existing machines) or is it possible to
    deploy a second cluster right next to the first one and install Wire on top?
-2. How was the Kubernetes cluster being deployed?
+2. How was the Kubernetes cluster deployed?
 
 Depending on the deployment method, the upgrade procedure may vary. It may be reasonable to test
 the upgrade in a non-production environment first.
@@ -22,7 +22,7 @@ can be found in the section about :ref:`restarting a machine in an kubernetes cl
 .. warning::
 
     For an in-place upgrade, it is *NOT* recommended to go straight to the latest Kubernetes
-    version. Instead, one should upgrade step by step to each minor version.
+    version. Instead, one should upgrade step by step between each minor version.
 
 
 Manually
@@ -31,15 +31,15 @@ Manually
 Doing an upgrade by hand is cumbersome and error-prone, which is why there are tools and
 automation for this procedure. The high-level steps would be:
 
-1. control plane (also see a more detailed `list <https://kubernetes.io/docs/tasks/administer-cluster/cluster-upgrade/#manual-deployments>`__)
+1. upgrade the control plane (also see a more detailed `list <https://kubernetes.io/docs/tasks/administer-cluster/cluster-upgrade/#manual-deployments>`__)
     a) all *etcd* instances
     b) api-server on each control-plane host
     c) controllers, scheduler,
-2. nodes (order may vary, depending on whether the kube-components run in containers)
+2. upgrade the nodes (order may vary, depending on whether the kube-components run in containers)
     * kubelet
     * kube-proxy
     * container runtime
-3. clients (``kubectl``, e.g. on workstations or in pipelines)
+3. then upgrade the clients (``kubectl``, e.g. on workstations or in pipelines)
 
 *For more details, please refer to the official documentation:*
 `Upgrade A Cluster <https://kubernetes.io/docs/tasks/administer-cluster/cluster-upgrade/>`__
@@ -72,7 +72,7 @@ with Kubespray 2.14):
 Kubespray takes care of bringing the new binaries into position on each machine, restarting
 the components, and draining/uncordon nodes.
 
-*For more details and commands, please refer to the official documentation:*
+*For more details please refer to the official documentation:*
 `Upgrading Kubernetes in Kubespray <https://kubespray.io/#/docs/upgrades>`__
 
 


### PR DESCRIPTION
Adds docs on how to restart machines that are part of a Kubernetes cluster. Additionally, it add entrypoints on how to upgrade a K8s cluster, and some external links on how to deal with etcd in the context of K8s.

## Checklist:

Please tick the following before making your PR:

* [X] I ran `make` on this branch to build the docs and there are **no WARNINGs**.
* [X] After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.
