### PR TITLE
enable fulltoc extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build
-        run: make
+        run: make docker docs

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -13,7 +13,7 @@ in
       pkgs.zip
       pkgs.gnumake
 
-      (pkgs.python3.withPackages (ps: with ps; [ sphinx recommonmark rst2pdf sphinx-autobuild ]))
+      (pkgs.python3.withPackages (ps: with ps; [ sphinx recommonmark rst2pdf sphinx-autobuild sphinxcontrib-fulltoc ]))
     ];
   };
 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -430,6 +430,14 @@ test = ["pytest"]
 
 [[package]]
 category = "main"
+description = "Include a full table of contents in your Sphinx HTML sidebar"
+name = "sphinxcontrib-fulltoc"
+optional = false
+python-versions = "*"
+version = "1.2.0"
+
+[[package]]
+category = "main"
 description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
 name = "sphinxcontrib-htmlhelp"
 optional = false
@@ -519,7 +527,7 @@ docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "696a10dd9b1544d38df40e70a46897e1a992583a289bc41b4a33aa52b2ad1c10"
+content-hash = "25df9311d15c37eaef40737613b2e2cacd6a0b5753945a19daf4068e68da3cfc"
 lock-version = "1.0"
 python-versions = "^3.7"
 
@@ -797,6 +805,9 @@ sphinxcontrib-applehelp = [
 sphinxcontrib-devhelp = [
     {file = "sphinxcontrib-devhelp-1.0.2.tar.gz", hash = "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"},
     {file = "sphinxcontrib_devhelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e"},
+]
+sphinxcontrib-fulltoc = [
+    {file = "sphinxcontrib-fulltoc-1.2.0.tar.gz", hash = "sha256:c845d62fc467f3135d4543e9f10e13ef91852683bd1c90fd19d07f9d36757cd9"},
 ]
 sphinxcontrib-htmlhelp = [
     {file = "sphinxcontrib-htmlhelp-1.0.3.tar.gz", hash = "sha256:e8f5bb7e31b2dbb25b9cc435c8ab7a79787ebf7f906155729338f3156d93659b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ Sphinx = "^3.5.2"
 recommonmark = "^0.7.1"
 awscli = "^1.19.28"
 sphinx-autobuild = "^2021.3.14"
+sphinxcontrib-fulltoc = "^1.2.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/shell.nix
+++ b/shell.nix
@@ -2,6 +2,6 @@
 pkgs.mkShell {
   buildInputs = with pkgs; [
     gnumake
-    (python3.withPackages (ps: with ps; [ sphinx recommonmark awscli rst2pdf ]))
+    (python3.withPackages (ps: with ps; [ sphinx recommonmark awscli rst2pdf sphinxcontrib-fulltoc ]))
   ];
 }

--- a/src/conf.py
+++ b/src/conf.py
@@ -29,7 +29,8 @@ version = "0.0.1"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'rst2pdf.pdfbuilder'
+    'rst2pdf.pdfbuilder',
+    'sphinxcontrib.fulltoc'
 ]
 
 # Grouping the document tree into PDF files. List of tuples


### PR DESCRIPTION
Improves the sidebar to include the full table of contents, making navigation easier.

Example screenshot with this extension:

![full_toc](https://user-images.githubusercontent.com/2112744/111680061-1e16ac00-8822-11eb-9955-f4a5588a5ca6.png)

instead of the current

![toc_current](https://user-images.githubusercontent.com/2112744/111680407-79e13500-8822-11eb-8366-5f553da56d15.png)


WIP:
* [x] also install via nix and include in docker image (i.e. change pipeline to re-build docker image first)
