### PR TITLE
Fix docker workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,6 @@ COPY . /wire-docs
 RUN nix-env -f /wire-docs/nix/default.nix -iA env && \
     rm -rf /wire-docs
 
+WORKDIR /mnt
+
 ENV USE_POETRY=0

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,4 @@ COPY . /wire-docs
 RUN nix-env -f /wire-docs/nix/default.nix -iA env && \
     rm -rf /wire-docs
 
-SHELL ["/bin/bash", "-c"]
-ENTRYPOINT "/bin/bash"
-
 ENV USE_POETRY=0

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ docs-pdf:
 docs-all:
 	docker run --rm -v $$(pwd):/mnt $(DOCKER_USER)/$(DOCKER_IMAGE):$(DOCKER_TAG) make clean html pdf
 
+.PHONY: clean
+clean:
+	rm -rf "$(BUILDDIR)"
+
 # Only build part of the documentation
 # See 'exclude_patterns' in source/conf.py
 docs-administrate:
@@ -66,8 +70,7 @@ else
 endif
 
 .PHONY: dev-run
-dev-run:
-	rm -rf "$(BUILDDIR)"
+dev-run: clean
 ifeq ($(USE_POETRY), 1)
 	source $$HOME/.poetry/env && \
 	poetry run sphinx-autobuild \


### PR DESCRIPTION
I am not sure what purpose the Entrypoint was serving, but it was causing `make docs` to fail. 

## Checklist:

Please tick the following before making your PR:

* [ ] I ran `make` on this branch to build the docs and there are **no WARNINGs**.
* [ ] After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.
