### PR TITLE
Add definitions for qualified IDs and names.

### DIFF
--- a/src/understand/federation/api.rst
+++ b/src/understand/federation/api.rst
@@ -8,6 +8,32 @@ The Federation API consists of two *layers*:
   2. Between other components
 
 
+Qualified Identifiers and Names
+-----------
+
+The federated (and consequently distributed) architecture is reflected in the
+structure of the various identifiers and names used in the API. In the context
+of federation, every identifier has to be a *qualified* identifier. This means
+that in addition to other information carried by the identifier, it also
+includes the domain name of the backend it is associated with. While other parts
+of some identifiers may change, the domain name is static.
+
+In particular, we use the following identifiers throughout the API:
+
+* Qualified User ID (QUID): `user_uuid@backend-domain.com`
+* Qualified User Name (QUN): `user_name@backend-domain.com`
+* Qualified Device ID (QDID) attached to a QUID: `device_uuid.user_uuid@backend-domain.com`
+* Qualified Conversation/Group ID (QCID/QGID): `backend-domain.com/groups/group_uuid`
+* Qualified Team ID (QDID): `backend-domain.com/teams/team_uuid`
+
+While the canonical representation for purposes of visualization is as displayed
+above, the API often decomposes the qualified identifiers into an (unqualified)
+id and a domain name.
+
+TODO: Link to protobuf definition or an example later in this chapter.
+TODO: Note how we sometimes use "handle" to refer to (qualified?) id?
+TODO: Should we include a proper definition for user display names here, i.e. a regex or similar?
+
 API between Federators
 -----------------------
 

--- a/src/understand/federation/api.rst
+++ b/src/understand/federation/api.rst
@@ -12,27 +12,26 @@ Qualified Identifiers and Names
 -------------------------------
 
 The federated (and consequently distributed) architecture is reflected in the
-structure of the various identifiers and names used in the API. In the context
-of federation, every identifier has to be a *qualified* identifier. This means
-that in addition to other information carried by the identifier, it also
-includes the domain name of the backend it is associated with. While other parts
-of some identifiers may change, the domain name is static.
+structure of the various identifiers and names used in the API. Before
+federation, identifiers were only unique in the context of a single backend; for
+federation, they are made globally unique by combining them with the federation
+domain of their backend. We call these combined identifiers *qualified*
+identifiers. While other parts of some identifiers or names may change, the
+domain name (i.e. the qualifying part) is static.
 
 In particular, we use the following identifiers throughout the API:
 
-* Qualified User ID (QUID): `user_uuid@backend-domain.com`
-* Qualified User Name (QUN): `user_name@backend-domain.com`
-* Qualified Device ID (QDID) attached to a QUID: `device_uuid.user_uuid@backend-domain.com`
-* Qualified Conversation/Group ID (QCID/QGID): `backend-domain.com/groups/group_uuid`
-* Qualified Team ID (QDID): `backend-domain.com/teams/team_uuid`
+* :ref:`Qualified User ID <qualified-user-id>` (QUID): `user_uuid@backend-domain.com`
+* :ref:`Qualified User Name <qualified-user-name>` (QUN): `user_name@backend-domain.com`
+* :ref:`Qualified Device ID <qualified-device-id>` (QDID) attached to a QUID: `device_uuid.user_uuid@backend-domain.com`
+* :ref:`Qualified Conversation <qualified-conversation-id>`/:ref:`Group ID <qualified-group-id>` (QCID/QGID): `backend-domain.com/groups/group_uuid`
+* :ref:`Qualified Team ID <qualified-team-id>` (QTID): `backend-domain.com/teams/team_uuid`
 
 While the canonical representation for purposes of visualization is as displayed
 above, the API often decomposes the qualified identifiers into an (unqualified)
-id and a domain name.
+id and a domain name. In the code and API documentation, we sometimes call a
+qualified username a "handle".
 
-TODO: Link to protobuf definition or an example later in this chapter.
-TODO: Note how we sometimes use "handle" to refer to (qualified?) id?
-TODO: Should we include a proper definition for user display names here, i.e. a regex or similar?
 
 API between Federators
 -----------------------

--- a/src/understand/federation/api.rst
+++ b/src/understand/federation/api.rst
@@ -30,7 +30,7 @@ In particular, we use the following identifiers throughout the API:
 While the canonical representation for purposes of visualization is as displayed
 above, the API often decomposes the qualified identifiers into an (unqualified)
 id and a domain name. In the code and API documentation, we sometimes call a
-qualified username a "handle".
+username a "handle" and a qualified username a "qualified handle".
 
 
 API between Federators

--- a/src/understand/federation/api.rst
+++ b/src/understand/federation/api.rst
@@ -9,7 +9,7 @@ The Federation API consists of two *layers*:
 
 
 Qualified Identifiers and Names
------------
+-------------------------------
 
 The federated (and consequently distributed) architecture is reflected in the
 structure of the various identifiers and names used in the API. In the context

--- a/src/understand/federation/api.rst
+++ b/src/understand/federation/api.rst
@@ -32,9 +32,10 @@ above, the API often decomposes the qualified identifiers into an (unqualified)
 id and a domain name. In the code and API documentation, we sometimes call a
 username a "handle" and a qualified username a "qualified handle".
 
-Besides the above names and identifiers, there are also user display names
-(sometimes also referred to as "profile names"), which are not unique on the
-user's backend, can be changed by the user at any time and are not qualified.
+Besides the above names and identifiers, there are also user :ref:`display names
+<display-name>` (sometimes also referred to as "profile names"), which are not
+unique on the user's backend, can be changed by the user at any time and are not
+qualified.
 
 
 API between Federators

--- a/src/understand/federation/api.rst
+++ b/src/understand/federation/api.rst
@@ -32,6 +32,10 @@ above, the API often decomposes the qualified identifiers into an (unqualified)
 id and a domain name. In the code and API documentation, we sometimes call a
 username a "handle" and a qualified username a "qualified handle".
 
+Besides the above names and identifiers, there are also user display names
+(sometimes also referred to as "profile names"), which are not unique on the
+user's backend, can be changed by the user at any time and are not qualified.
+
 
 API between Federators
 -----------------------

--- a/src/understand/federation/glossary.rst
+++ b/src/understand/federation/glossary.rst
@@ -23,3 +23,47 @@ Backend
 Asset
 
    Any file or image sent via Wire (uploaded to and downloaded from a backend).
+
+.. _qualified-user-id:
+
+Qualified User Identifier (QUID)
+
+  A combination of a UUID (unique on the user's backend) and a domain.
+
+.. _qualified-user-name:
+
+Qualified User Identifier (QUN)
+
+  A combination of a name that is unique on the user's backend and a domain. The
+  name is a string consisting of 2-256 characters which are either lower case
+  alphanumeric, dashes, underscores or dots. See `here
+  <https://github.com/wireapp/wire-server/blob/f683299a03207acb505254ff3121213383d0b672/libs/types-common/src/Data/Handle.hs#L76-L93>`_
+  for the code defining the rules for user names.
+
+.. _qualified-device-id:
+
+Qualified Device Identifier (QDID)
+
+  A combination of a randomly generated string of either 10 or 15 characters
+  concatenated with a dot and the QUID of the associated user. The resulting
+  string is unique on the backend of the associated user.
+
+.. _qualified-group-id:
+
+Qualified Group Identifier (QGID)
+
+  The string `backend-domain.com/groups/` concatenated with a UUID that is
+  unique on a given backend.
+
+.. _qualified-conversation-id:
+
+Qualified Conversation Identifier (QCID)
+
+  The same as a :ref:`QGID <qualified-group-id>`.
+
+.. _qualified-team-id:
+
+Qualified Team Identifier (QTID)
+
+  The string `backend-domain.com/teams/` concatenated with a UUID that is
+  unique on a given backend.

--- a/src/understand/federation/glossary.rst
+++ b/src/understand/federation/glossary.rst
@@ -38,15 +38,16 @@ Qualified User Name (QUN)
   name is a string consisting of 2-256 characters which are either lower case
   alphanumeric, dashes, underscores or dots. See `here
   <https://github.com/wireapp/wire-server/blob/f683299a03207acb505254ff3121213383d0b672/libs/types-common/src/Data/Handle.hs#L76-L93>`_
-  for the code defining the rules for user names. Note that in the wire-server source code, user names are called 'Handle' and qualified user names 'Qualified Handle'.
+  for the code defining the rules for user names. Note that in the wire-server
+  source code, user names are called 'Handle' and qualified user names
+  'Qualified Handle'.
 
 .. _qualified-device-id:
 
 Qualified Device Identifier (QDID)
 
-  A combination of a device identifier (a hash of the public key generated for a user's device)
-  concatenated with a dot and the QUID of the associated user. The resulting
-  string is unique on the backend of the associated user.
+  A combination of a device identifier (a hash of the public key generated for a
+  user's device) concatenated with a dot and the QUID of the associated user.
 
 .. _qualified-group-id:
 

--- a/src/understand/federation/glossary.rst
+++ b/src/understand/federation/glossary.rst
@@ -68,3 +68,10 @@ Qualified Team Identifier (QTID)
 
   The string `backend-domain.com/teams/` concatenated with a UUID that is
   unique on a given backend.
+
+.. _display-name:
+
+(User) Profile/Display Name
+
+  The profile/display name of a user is a UTF-8 encoded string with 1-128
+  characters.


### PR DESCRIPTION
This PR adds a brief discussion around qualified IDs and names, as well as some "definitions", which are really just examples. There are still some todos, as I wasn't sure how formal we want this section to be. Is there already a place where the user UUIDs and names are (formally) defined? If not, this might be a good place to do it.

Let me know what you think!

## Checklist:

Please tick the following before making your PR:

* [x] I ran `make` on this branch to build the docs and there are **no WARNINGs**.
* [x] After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.
