### PR TITLE
The cp command had the wrong filename

### DIFF
--- a/src/how-to/install/kubernetes.rst
+++ b/src/how-to/install/kubernetes.rst
@@ -13,7 +13,7 @@ From ``wire-server-deploy/ansible``:
 
 .. code:: shell
 
-  cp inventory/demo/hosts.example-demo.ini inventory/demo/hosts.ini
+  cp inventory/demo/hosts.example.ini inventory/demo/hosts.ini
 
 Open hosts.ini and replace `X.X.X.X` with the IP address of your virtual machine that you use for ssh access.  You can try using ``sed -i 's/X.X.X.X/1.2.3.4/g' hosts.ini``.
 


### PR DESCRIPTION
Calling the .ini file hosts.example-demo.ini  when the file in the Docker is actually called hosts.example.ini

(fill in your PR description)

## Checklist:

Please tick the following before making your PR:

* [x] I ran `make` on this branch to build the docs and there are **no WARNINGs**.
* [x] After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.
