### PR TITLE
Add full path for sed command

### DIFF
--- a/src/how-to/install/kubernetes.rst
+++ b/src/how-to/install/kubernetes.rst
@@ -15,7 +15,7 @@ From ``wire-server-deploy/ansible``:
 
   cp inventory/demo/hosts.example-demo.ini inventory/demo/hosts.ini
 
-Open hosts.ini and replace `X.X.X.X` with the IP address of your virtual machine that you use for ssh access.  You can try using ``sed -i 's/X.X.X.X/1.2.3.4/g' hosts.ini``.
+Open hosts.ini and replace `X.X.X.X` with the IP address of your virtual machine that you use for ssh access.  You can try using ``sed -i 's/X.X.X.X/1.2.3.4/g' inventory/demo/hosts.ini``.
 
 
 How to install kubernetes


### PR DESCRIPTION
If run as-is the command tries to address a hosts.ini file in the current folder, but the .ini file is actually in inventory/demo/

(fill in your PR description)

## Checklist:

Please tick the following before making your PR:

* [x] I ran `make` on this branch to build the docs and there are **no WARNINGs**.
* [x] After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.
