### PR TITLE
Switch git clone branch to develop

### DIFF
--- a/src/how-to/install/dependencies.rst
+++ b/src/how-to/install/dependencies.rst
@@ -22,7 +22,7 @@ updated. This fetches all the required Ansible roles needed to run the wire Ansi
 
 ::
 
-   git clone --branch master https://github.com/wireapp/wire-server-deploy.git
+   git clone --branch develop https://github.com/wireapp/wire-server-deploy.git
    cd wire-server-deploy
    git submodule update
 


### PR DESCRIPTION
As the documentation is currently presented, it recommends using master. Doing so leads to some files missing in later steps.
Changing this to cloning the develop branch instead of the master branch, allows the installation process to go further (though it still currently runs into trouble, see for reference https://pastebin.com/ggegKjeG )
I am not sure if the desired solution here is to change the instruction to use develop, or to fix the master branch so it includes the correct files, but here is a pull request in case the first option is the correct one.

(fill in your PR description)

## Checklist:

Please tick the following before making your PR:

* [x] I ran `make` on this branch to build the docs and there are **no WARNINGs**.
* [ x After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.
