### PR TITLE
lock default docker tag to an explicit version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ MKFILE_DIR = $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 
 DOCKER_USER   ?= quay.io/wire
 DOCKER_IMAGE  = alpine-sphinx
-DOCKER_TAG    ?= latest
+DOCKER_TAG    ?= 0.0.32
 
 # You can set these variables (with a ?=) from the command line, and also
 # from the environment.


### PR DESCRIPTION
"latest" may be too old for someone who downloaded "latest" before.

We can either always pull before running; or bump the version each time there is a relevant tooling change. This implements the latter approach for now (needs to be manually bumped if the nix-based tooling changes, e.g. new plugins).

fixes #143 