### PR TITLE
fix link to Backoffice chart

### DIFF
--- a/src/how-to/administrate/users.rst
+++ b/src/how-to/administrate/users.rst
@@ -5,7 +5,7 @@ Investigative tasks (e.g. searching for users as server admin)
 
 This page requires that you have root access to the machines where kubernetes runs on, or have kubernetes permissions allowing you to port-forward arbitrary pods and services.
 
-If you have the `backoffice` pod installed, see also the `backoffice README <https://github.com/wireapp/wire-server-deploy/tree/develop/charts/backoffice>`__.
+If you have the `backoffice` pod installed, see also the `backoffice README <https://github.com/wireapp/wire-server/tree/develop/charts/backoffice>`__.
 
 If you don't have `backoffice`, see below for some options:
 


### PR DESCRIPTION
trivial change; I did *not* do the following:

* [ ] I ran `make` on this branch to build the docs and there are **no WARNINGs**.
* [ ] After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.
