### PR TITLE
fix broken link to Helm value overrides section anchor

### DIFF
--- a/src/how-to/install/helm-prod.rst
+++ b/src/how-to/install/helm-prod.rst
@@ -156,7 +156,7 @@ As part of configuring wire-server, we need to change some values, and provide s
 
 .. note::
 
-    this part of the process makes use of overrides for helm charts. You may wish to read :ref:`understand-helm-overrides` first.*
+    This part of the process makes use of overrides for helm charts. You may wish to read :ref:`understand-helm-overrides` first.
 
 
 .. code:: shell

--- a/src/how-to/install/helm.rst
+++ b/src/how-to/install/helm.rst
@@ -106,8 +106,7 @@ How to install wire-server itself
 
 .. note::
 
-    the following makes use of overrides for helm charts. You may wish to read :ref:`understand-helm-overrides` first.*
-
+    The following makes use of overrides for helm charts. You may wish to read :ref:`understand-helm-overrides` first.
 
 Change back to the wire-server-deploy directory.  Copy example demo values and secrets:
 

--- a/src/how-to/install/logging.rst
+++ b/src/how-to/install/logging.rst
@@ -78,7 +78,9 @@ Deploying fluent-bit
 Configuring fluent-bit
 ----------------------
 
-*Note: the following makes use of overrides for helm charts. You may wish to read :ref:`understand-helm-overrides` first.*
+.. note::
+
+    The following makes use of overrides for helm charts. You may wish to read :ref:`understand-helm-overrides` first.
 
 Per pod-template, you can specify what parsers ``fluent-bit`` needs to
 use to interpret the pod's logs in a structured way. By default, it just

--- a/src/how-to/install/monitoring.rst
+++ b/src/how-to/install/monitoring.rst
@@ -22,7 +22,9 @@ You need to have wire-server installed, see either of
 How to install Prometheus and Grafana on Kubernetes using Helm
 ---------------------------------------------------------------
 
-*Note: the following makes use of overrides for helm charts. You may wish to read :ref:`understand-helm-overrides` first.*
+.. note::
+
+    The following makes use of overrides for helm charts. You may wish to read :ref:`understand-helm-overrides` first.
 
 Create an override file:
 


### PR DESCRIPTION
Links appear to have been broken since their introduction due to RST not supporting nesting links in italics (or any inline markup, for that matter, unless you're down for some [*interesting* workarounds](https://stackoverflow.com/a/4836544/3826702)).

This change uses the "note" box markup for the affected links (which was already used in one instance).

* [x] I ran `make` on this branch to build the docs and there are **no WARNINGs**.
* [x] After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.
