### PR TITLE
Previous commands call this folder "wire-server", but this structure …

### DIFF
--- a/src/how-to/install/includes/helm_dns-ingress-troubleshooting.inc.rst
+++ b/src/how-to/install/includes/helm_dns-ingress-troubleshooting.inc.rst
@@ -50,7 +50,7 @@ You should now have the following directory structure:
   ├── nginx-ingress-services
   │   ├── secrets.yaml
   │   └── values.yaml
-  └── my-wire-server
+  └── wire-server
       ├── secrets.yaml
       └── values.yaml
 


### PR DESCRIPTION
…shows it as "my-wire-server" which is inconsistent

99% sure this is not intentional is just a tiny error, and needs to be fixed.

(fill in your PR description)

## Checklist:

Please tick the following before making your PR:

* [ ] I ran `make` on this branch to build the docs and there are **no WARNINGs**.
* [ ] After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.
