### PR TITLE
Simple fix to keep SRV record in the federation docs within page

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -46,6 +46,8 @@ pdf_documents = [
 # Add section number to section
 referencespdf_use_numbered_links = True
 
+pdf_fit_mode = "shrink"
+
 # see https://rst2pdf.org/static/manual.pdf for more pdf configuration options
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
As the title says. The added option makes `rst2pdf` shrink anything that doesn't fit within the page. From what I can see, this only affects the SRV record in the `Discovery` section.

## Checklist:

Please tick the following before making your PR:

* [x] I ran `make` on this branch to build the docs and there are **no WARNINGs**.
* [x] After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.
