### PR TITLE
Enable compilation to latex and add release field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ docs:
 docs-pdf:
 	docker run --rm -v $$(pwd):/mnt $(DOCKER_USER)/$(DOCKER_IMAGE):$(DOCKER_TAG) make clean pdf
 
+.PHONY: docs-latex
+docs-latex:
+	docker run --rm -v $$(pwd):/mnt $(DOCKER_USER)/$(DOCKER_IMAGE):$(DOCKER_TAG) make clean latex
+
 .PHONY: docs-all
 docs-all:
 	docker run --rm -v $$(pwd):/mnt $(DOCKER_USER)/$(DOCKER_IMAGE):$(DOCKER_TAG) make clean html pdf

--- a/src/conf.py
+++ b/src/conf.py
@@ -20,7 +20,8 @@
 project = 'Wire'
 copyright = '2021, Wire'
 author = 'Wire Swiss GmbH'
-version = "0.0.2"
+version = '0.0.2'
+release = '0.0.2'
 
 
 # -- General configuration ---------------------------------------------------
@@ -42,6 +43,12 @@ pdf_documents = [
     ('understand/federation/index', 'wire_federation', 'Wire Federation', 'Wire Swiss GmbH')
 ]
 
+latex_documents = [
+    ('understand/federation/index', 'main.tex', 'Wire Federation', 'Wire Swiss GmbH', 'howto', 'False')
+]
+
+
+
 
 # Add section number to section
 referencespdf_use_numbered_links = True
@@ -54,7 +61,7 @@ pdf_fit_mode = "shrink"
 templates_path = ['_templates']
 
 html_sidebars = {
-    # instead of a wildcard **, a regex could optionally 
+    # instead of a wildcard **, a regex could optionally
     # show the version sidebar only on some pages but not all of them.
     '**': ['versioning.html', 'globaltoc.html', 'sourcelink.html', 'searchbox.html'],
 }

--- a/src/conf.py
+++ b/src/conf.py
@@ -21,7 +21,8 @@ project = 'Wire'
 copyright = '2021, Wire'
 author = 'Wire Swiss GmbH'
 version = '0.0.2'
-release = '0.0.2'
+# the 'release' variable is used in latex-based PDF generation
+release = version
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
As the title says, this PR does some minor changes to the Makefile and the `conf.py` to allow for compilation to LaTeX. It also adds a `release` field, which contains the same value as the `version` field. From what I could see, this doesn't change anything in the extracted HTML docs, but since LaTeX seems to only display the `release`, it seems like a worthwhile workaround for now.

## Checklist:

Please tick the following before making your PR:

* [x] I ran `make` on this branch to build the docs and there are **no WARNINGs**.
* [x] After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.
