### PR TITLE
PDF via latex target, and the full texlive dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,10 @@ dev-pdf: pdf
 	$(OPEN) build/pdf/wire_federation.pdf 2>&1 > /dev/null &
 	find src/ | entr make pdf
 
+.PHONY: latex-pdf
+latex-pdf: latex
+	make -C build/latex all && echo "" && echo "Resulting PDF can be found in ./build/latex/main.pdf"
+
 .PHONY: help
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -13,6 +13,7 @@ in
       pkgs.zip
       pkgs.gnumake
       pkgs.entr
+      pkgs.texlive.combined.scheme-full
 
       (pkgs.python3.withPackages (ps: with ps; [ sphinx recommonmark rst2pdf sphinx-autobuild sphinxcontrib-fulltoc sphinx-multiversion ]))
     ];


### PR DESCRIPTION
This adds the texlive ecosystem of tools (note to nix people: `pkgs.texlive.combined.scheme-medium` was not enough), which adds a few extra GB initially; and adds a target to create a PDF via latex. That resulting PDF looks nicer than the rst2pdf tooling.

Once a docker image gets built with this tooling, we can add another inside-docker target.