### PR TITLE
Rename ingress to federation ingress and harmonize capitalization of Federator and Federation Ingress

### DIFF
--- a/src/understand/federation/api.rst
+++ b/src/understand/federation/api.rst
@@ -4,8 +4,9 @@ API
 ====
 
 The Federation API consists of two *layers*:
-  1. Between federators
-  2. Between other components
+  1. Between two backends (i.e. between a `Federator` and a `Federation
+     Ingress`)
+  2. Between backend-internal components
 
 .. _qualified-identifiers-and-names:
 
@@ -42,7 +43,7 @@ qualified.
 API between Federators
 -----------------------
 
-The layer between federators acts as an envelope for communication between other
+The layer between `Federator`s acts as an envelope for communication between other
 components of wire server. It uses Protocol Buffers (protobuf from here onwards)
 for serialization over gRPC. The latest protobuf schema can be inspected at
 `the wire-server repository
@@ -52,7 +53,7 @@ All gRPC calls are made via a :ref:`mutually authenticated TLS connection
 <authentication>` and subject to a :ref:`general <authorization>`, as well as a
 :ref:`per-request authorization <per-request-authorization>` step.
 
-The ``Inward`` service defined in the schema is used between federators. It
+The ``Inward`` service defined in the schema is used between `Federator`s. It
 supports one rpc called ``call`` which requires a ``Request`` and returns an
 ``InwardResponse``. These objects looks like this:
 
@@ -92,7 +93,7 @@ supports one rpc called ``call`` which requires a ``Request`` and returns an
     }
 
 
-The ``component`` field in ``Request`` tells the federator which components this
+The ``component`` field in ``Request`` tells the `Federator` which components this
 request is meant for and the rest of the arguments are details of the HTTP
 request which must be made against the component. It intentionally supports a
 restricted set of parameters to ensure that the API is simple.
@@ -101,11 +102,11 @@ API From Components to Federator
 --------------------------------
 
 Between two federated backends, the components talk to each other via their
-respective federators and ingress'. When making the call to the federator, the
+respective `Federator`s and ingress'. When making the call to the `Federator`, the
 components use protobuf over gRPC. They call the ``Outward`` service, which also
 supports one rpc called ``call``. This rpc requires a ``FederatedRequest``
 object, which contains a ``Request`` object as defined above, as well as the
-domain of the destination federator. The rpc returns an ``OutwardResponse``,
+domain of the destination `Federator`. The rpc returns an ``OutwardResponse``,
 which can either contains a body with the returned information or an
 ``OutwardError``, these objects look like this:
 
@@ -151,8 +152,8 @@ which can either contains a body with the returned information or an
 API From Federator to Components
 --------------------------------
 
-The components expose a REST API over HTTP to be consumed by the federator. All
-the paths start with ``/federation``. When a federator recieves a request like
+The components expose a REST API over HTTP to be consumed by the `Federator`. All
+the paths start with ``/federation``. When a `Federator` recieves a request like
 this (shown as JSON for convenience):
 
 .. code-block:: json
@@ -164,7 +165,7 @@ this (shown as JSON for convenience):
      "originDomain": "somedomain.example.com"
    }
 
-The federator connects to Brig and makes an HTTP request which looks like this:
+The `Federator` connects to Brig and makes an HTTP request which looks like this:
 
 .. code-block::
 
@@ -192,7 +193,7 @@ path-traversal attacks such as ``/federation/../users/by-handle``.
 List of Federation APIs exposed by Components
 ---------------------------------------------
 
-Each component of the backend provides an API towards the federator for access
+Each component of the backend provides an API towards the `Federator` for access
 by other backends. For example on how these APIs are used, see the section on
 :ref:`end-to-end flows<end-to-end-flows>`.
 
@@ -267,9 +268,9 @@ End-to-End Flows
 
 In the following end-to-end flows, we focus on the interaction between the Brigs
 and Galleys of federated backends. While the interactions are facilitated by the
-Federator and Ingress components of the backends involved, which handle the
-necessary discovery, authentication and authorization steps, we won't mention
-these steps explicitly each time to keep the flows simple.
+`Federator` and `Federation Ingress` components of the backends involved, which
+handle the necessary discovery, authentication and authorization steps, we won't
+mention these steps explicitly each time to keep the flows simple.
 
 Additionally we assume that the backend domain and the infra domain of the
 respecivebackends involved are the same and each domain identifies a distinct
@@ -287,13 +288,13 @@ In this flow, the user `A` at `backend-a.com` tries to search for user `B` at
    `B@backend-b.com` into the search field of their Wire client.
 #. The client issues a query to ``/search/contacts`` of the Brig searching for
    `B` at `backend-b.com`.
-#. The Brig in `A`'s backend asks its local Federator to query the
+#. The Brig in `A`'s backend asks its local `Federator` to query the
    ``search-users`` endpoint of B's backend for `B`.
-#. `A`'s Federator queries `B`'s Brig via `B`'s Ingress and Federator as
-   requested.
+#. `A`'s `Federator` queries `B`'s Brig via `B`'s `Federation Ingress` and
+   `Federator` as requested.
 #. `B`'s Brig replies with with `B`'s user name and qualified handle, the
-   response goes through `B`'s Federator and Ingress, as well as `A`'s Federator
-   before it reaches `A`'s Brig.
+   response goes through `B`'s `Federator` and `Federation Ingress`, as well as
+   `A`'s `Federator` before it reaches `A`'s Brig.
 #. `A`'s Brig forwards that information to `A`'s client.
 
 Conversation Establishment
@@ -306,19 +307,19 @@ wants to establish a conversation with `B`.
    `A` chooses to create a conversation with `B`.
 #. `A`'s client issues a ``/users/backend-b.com/B/prekeys`` query to `A`'s
    Brig.
-#. `A`'s Brig asks its Federator to query the ``claim-prekey-bundle`` endpoint
+#. `A`'s Brig asks its `Federator` to query the ``claim-prekey-bundle`` endpoint
    of `B`'s backend using `B`'s user id.
-#. `B`'s Ingress forwards the query to the Federator, who in turn forwards it to
+#. `B`'s `Federation Ingress` forwards the query to the `Federator`, who in turn forwards it to
    the local Brig.
 #. `B`'s Brig replies with a prekey bundle for each of `B`'s clients, which is
-   forwarded to `A`'s Brig via `B`'s Federator and Ingress, as well as `A`'s
-   Federator.
+   forwarded to `A`'s Brig via `B`'s `Federator` and `Federation Ingress`, as well as `A`'s
+   `Federator`.
 #. `A`'s Brig forwards that information to `A`'s client.
 #. `A`'s client queries the ``/conversations`` endpoint of its Galley
    using `B`'s user id.
 #. `A`'s Galley creates the conversation locally and queries the
    ``register-conversation`` endpoint of `B`'s Galley (again via its local
-   Federator, as well as `B`'s Ingress and Federator) to inform it about the new
+   `Federator`, as well as `B`'s `Federation Ingress` and `Federator`) to inform it about the new
    conversation, including the conversation metadata in the request.
 #. `B`'s Galley registers the conversation locally and confirms the query.
 #. `B`'s Galley notifies `B`'s client of the creation of the conversation.
@@ -340,7 +341,7 @@ Having established a conversation with user `B` at `backend-b.com`, user `A` at
 #. `A`'s Galley sends the message to all clients in the conversation that are
    part of `A`'s backend.
 #. `A`'s Galley queries the ``receive-message`` endpoint on `B`'s Galley via its
-   Federator and `B`'s Ingress and Federator.
+   `Federator` and `B`'s `Federation Ingress` and `Federator`.
 #. `B`'s Galley will propagate the message to all local clients involved in the
    conversation.
 
@@ -363,6 +364,6 @@ Having received a message from user `A` at `backend-a.com`, user `B` at
 #. `A`'s Galley sends the message to all clients in the conversation that are
    part of `A`'s backend.
 #. `A`'s Galley queries the ``receive-message`` endpoint on `B`'s Galley via its
-   Federator and `B`'s Ingress and Federator.
+   `Federator` and `B`'s `Federation Ingress` and `Federator`.
 #. `B`'s Galley will propagate the message to all local clients involved in the
    conversation.

--- a/src/understand/federation/architecture.rst
+++ b/src/understand/federation/architecture.rst
@@ -5,11 +5,12 @@ Architecture
 -------------
 
 To facilitate connections between federated backends, two new components are
-added to each backend: :ref:`ingress` and :ref:`federator`. The `ingress` is, as
-the name suggests the ingress point for incoming connections, where requests
-from other backends are then forwarded to the `federator`, which further
-processes the requests. In addition, the `federator` also acts as *egress* point
-for requests from internal backend components to other, remote backends.
+added to each backend: :ref:`Federation Ingress <federation_ingress>` and
+:ref:`Federator <federator>`. The `Federation Ingress` is, as the name suggests
+the ingress point for incoming connections from other backends, which are then
+forwarded to the `Federator`. The `Federator` then further processes the
+requests. In addition, the `Federator` also acts as *egress* point for requests
+from internal backend components to other, remote backends.
 
 .. image:: img/federated-backend-architecture.png
    :width: 100%
@@ -43,21 +44,21 @@ Backend components
 ^^^^^^^^^^^^^^^^^^
 
 In addition to the regular components of a Wire backend, two additional
-components are added to enable federation with other backends: The `Ingress` and
-the `Federator`. Other Wire components use these two components to contact other
-backends and respond to queries originating from remote backends.
+components are added to enable federation with other backends: The `Federation
+Ingress` and the `Federator`. Other Wire components use these two components to
+contact other backends and respond to queries originating from remote backends.
 
 The following subsections briefly introduce the individual components, their
 state and their functionality. The semantics of backend-to-backend communication
 will be explained in more detail in the Section on :ref:`Federation API
 <federation-api>`.
 
-.. _ingress:
+.. _federation_ingress:
 
-Ingress
-~~~~~~~
+Federation Ingress
+~~~~~~~~~~~~~~~~~~
 
-The ingress is a `kubernetes ingress
+The `Federation Ingress` is a `kubernetes ingress
 <https://kubernetes.io/docs/concepts/services-networking/ingress/>`_ and uses
 `nginx <https://nginx.org/en/>`_ as its underlying software.
 
@@ -71,7 +72,7 @@ Its functions are:
 
   - perform mutual :ref:`authentication` as part of the TLS connection
     establishment
-* forward requests to the local :ref:`federator` instance
+* forward requests to the local :ref:`Federator <federator>` instance
 
 
 .. _federator:
@@ -82,14 +83,14 @@ Federator
 .. warning:: As of July 2021, authentication is not fully implemented. See the
              section on :ref:`authentication` for more details.
 
-The federator acts as egress point for other backend components. It can be
+The `Federator` acts as egress point for other backend components. It can be
 configured to use an :ref:`allow list <allow-list>` to authorize incoming and
 outgoing connections, and it keeps an X.509 client certificate for the backend's
 infra domain to authenticate itself towards other backends. Additionally, it
 requires a connection to a DNS resolver to :ref:`discover<discovery>` other
 backends.
 
-When receiving a request from an internal component, the federator will:
+When receiving a request from an internal component, the `Federator` will:
 
 #. If enabled, ensure the target domain is in the :ref:`allow list <allow-list>`
 #. :ref:`discover <discovery>` the other backend,
@@ -99,10 +100,10 @@ When receiving a request from an internal component, the federator will:
 #. forward the response back to the originating component (and eventually to the
    originating Wire client).
 
-The federator also implements the authorization logic for incoming requests and
-acts as intermediary between the Ingress and the internal components. The
-'federator' will, for incoming requests from other backends (forwarded via the
-local :ref:`ingress`):
+The `Federator` also implements the authorization logic for incoming requests and
+acts as intermediary between the `Federation Ingress` and the internal
+components. The 'Rederator' will, for incoming requests from other backends
+(forwarded via the local :ref:`Federation Ingress <federation_ingress>`):
 
 #. Discover the backend domain claimed by the other backend,
 #. if enabled, ensure that the backend domain of the other backend is in the
@@ -123,17 +124,17 @@ external services. See `source code documentation
 functions include:
 
 * For incoming requests from other backends:  :ref:`per-request authorization<per-request-authorization>`
-* Outgoing requests to other backends are always sent via a local :ref:`federator` instance.
+* Outgoing requests to other backends are always sent via a local :ref:`Federator` instance.
 
 For more information of the functionalities provided to remote backends through
-their federator, see the :ref:`federated API documentation<api-endpoints>`.
+their `Federator`, see the :ref:`federated API documentation<api-endpoints>`.
 
 
 Backend to backend communication
 --------------------------------------------
 
-We require communication between the federator of one (sending) backend and the
-ingress of another (receiving) backend to be both mutually authenticated and
+We require communication between the `Federator` of one (sending) backend and
+the ingress of another (receiving) backend to be both mutually authenticated and
 authorized. More specifically, both backends need to ensure the following:
 
 :Authentication: Determine the identity (infra domain name) of the other
@@ -161,8 +162,8 @@ provisioned with one or more certificates which it trusts to authenticate
 certificates provided by other backends when accepting incoming connections from
 other backends.
 
-Conversely, every federator needs to be provisioned with a (client) certificate
-which it uses to authenticate itself towards other backends.
+Conversely, every `Federator` needs to be provisioned with a (client)
+certificate which it uses to authenticate itself towards other backends.
 
 Note that the client certificate is expected to be issued with the backend's
 infra domain as the subject alternative name (SAN), which is defined in `RFC
@@ -213,10 +214,11 @@ DNS Scope
 The network scope of the SRV record (as well as that of the DNS records for
 backend and infra domain), depends on the desired federation topology in the
 same way as other parameters such as the availability of the CA certificate that
-allows authentication of the Ingress' server certificate or the federator's
-client certificate. The general rule is that the SRV entry should be "visible"
-from the point of view of the desired federation partners. The exact scope
-strongly depends on the network architecture of the backends involved.
+allows authentication of the `Federation Ingress`' server certificate or the
+`Federator`'s client certificate. The general rule is that the SRV entry should
+be "visible" from the point of view of the desired federation partners. The
+exact scope strongly depends on the network architecture of the backends
+involved.
 
 SRV TTL and Caching
 ~~~~~~~~~~~~~~~~~~~

--- a/src/understand/federation/glossary.rst
+++ b/src/understand/federation/glossary.rst
@@ -29,27 +29,27 @@ Backend Domain
 Infrastructure Domain or Infra Domain
 
    The domain under which the :ref:`Federator <glossary_federator>` of a given
-   backend is reachable (via that backend's :ref:`Ingress <glossary_ingress>`)
+   backend is reachable (via that backend's :ref:`Ingress <glossary_federation_ingress>`)
    for other, remote backends.
 
-.. _glossary_ingress:
+.. _glossary_federation_ingress:
 
-Ingress
+Federation Ingress
 
-   Ingress is the first point of contact of a given :ref:`backend
+   Federation Ingress is the first point of contact of a given :ref:`backend
    <glossary_backend>` for other, remote backends. It also deals with the
-   :ref:`authentication` of incoming requests. See :ref:`here <ingress>` for
+   :ref:`authentication` of incoming requests. See :ref:`here <federation_ingress>` for
    more information.
 
 .. _glossary_federator:
 
 Federator
 
-   The federator is the local point of contact for :ref:`other backend
+   The `Federator` is the local point of contact for :ref:`other backend
    components <other-wire-server>` that want to make calls to remote backends.
    It is also the component that deals with the :ref:`authorization` of incoming
-   requests from other backends after they have passed the :ref:`ingress
-   <glossary_ingress>`. See :ref:`here <federator>` for more information.
+   requests from other backends after they have passed the :ref:`Federation Ingress
+   <glossary_federation_ingress>`. See :ref:`here <federator>` for more information.
 
 .. _glossary_asset:
 

--- a/src/understand/federation/introduction.rst
+++ b/src/understand/federation/introduction.rst
@@ -18,9 +18,10 @@ network.
 To enable federation, administrators of a Wire backend can decide to either
 specifically list the backends that they want to federate with, or to allow federation with all Wire backends reachable from the network.
 
-Federation is facilitated by two backend components: the *ingress*, which, as
-the name suggests, acts as ingress point for federated traffic and the
-*federator*, which acts as egress point and processes all ingress requests from the *ingress* after the authentication step.
+Federation is facilitated by two backend components: the *Federation Ingress*,
+which, as the name suggests, acts as ingress point for federated traffic and the
+*Federator*, which acts as egress point and processes all ingress requests from
+the Federation Ingress after the authentication step.
 
 Non-Goals
 ---------


### PR DESCRIPTION
This PR renames the `Ingress` to `Federation Ingress` to distinguish it from the other ingress component that deals with non-federation requests. The second ingress is not part of the federation docs, but if we don't rename, we will run into a collision sooner or later when this gets merged with non-federation documentation.

This PR also capitalizes all mentaions of `Federator` and `Federation Ingress` and typesets them as inline code.

## Checklist:

Please tick the following before making your PR:

* [x] I ran `make` on this branch to build the docs and there are **no WARNINGs**.
* [x] After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.
