### PR TITLE
Update docker image to include rtd theme and texlive binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ MKFILE_DIR = $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 
 DOCKER_USER   ?= quay.io/wire
 DOCKER_IMAGE  = alpine-sphinx
-DOCKER_TAG    ?= 0.0.32
+DOCKER_TAG    ?= 0.0.97
 
 # You can set these variables (with a ?=) from the command line, and also
 # from the environment.


### PR DESCRIPTION
When new dependencies are introduced, but if contributors use docker rather than the nix setup, it's necessary to bump the docker tag here.