### PR TITLE
webapp-config for the future

### DIFF
--- a/src/how-to/install/configure-federation.rst
+++ b/src/how-to/install/configure-federation.rst
@@ -291,6 +291,23 @@ galley and brig. You also need to set ``enableFederator`` to ``true``.
 Configure the webapp to enable federation and set your chosen backend domain one more time
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+You always have to set the following:
+
+.. code:: yaml
+
+    # override values for wire-server
+    # (e.g. under ./helm_vars/wire-server/values.yaml)
+    webapp:
+      envVars:
+        FEATURE_ENABLE_FEDERATION: "true"
+
+If you install a version of wire-server helm charts <= 2.117.0, then you also
+need to explicitly set the backend domain one more time. Releases from 2.118.0
+
+(TODO: confirm the change from webapp 2021-11-09 has made it into that release)
+
+onwards no longer need this environment variable.
+
 .. code:: yaml
 
     # override values for wire-server
@@ -298,7 +315,6 @@ Configure the webapp to enable federation and set your chosen backend domain one
     webapp:
       envVars:
         FEATURE_FEDERATION_DOMAIN: "example.com" # your chosen "backend domain"
-        FEATURE_ENABLE_FEDERATION: "true"
 
 Configure federator process to run and allow incoming traffic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This documentation change should only be merged after the next release is out containing that webapp change that discovers the federation domain.

Left as draft so this is not accidentally merged too early.

* [x] I ran `make` on this branch to build the docs and there are **no WARNINGs**.
* [x] After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.
