### PR TITLE
Dedicated «installing restund» page

### DIFF
--- a/src/how-to/install/ansible-VMs.rst
+++ b/src/how-to/install/ansible-VMs.rst
@@ -226,48 +226,8 @@ this step.
 Restund
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
--  In your ``hosts.ini`` file, in the ``[restund:vars]`` section, set
-   the ``restund_network_interface`` to the name of the interface
-   you want restund to talk to clients on. This value defaults to the
-   ``default_ipv4_address``, with a fallback to ``eth0``.
--  (optional) ``restund_peer_udp_advertise_addr=Y.Y.Y.Y``: set this to
-   the IP to advertise for other restund servers if different than the
-   ip on the 'restund_network_interface'. If using
-   'restund_peer_udp_advertise_addr', make sure that UDP (!) traffic
-   from any restund server (including itself) can reach that IP (for
-   ``restund <-> restund`` communication). This should only be necessary
-   if you're installing restund on a VM that is reachable on a public IP
-   address but the process cannot bind to that public IP address
-   directly (e.g. on AWS VPC VM). If unset, ``restund <-> restund`` UDP
-   traffic will default to the IP in the ``restund_network_interface``.
+For instructions on how to install Restund, see :ref:`this page <_install-restund>`.
 
-.. code:: ini
-
-   [all]
-   (...)
-   restund01         ansible_host=X.X.X.X
-
-   (...)
-
-   [all:vars]
-   ## Set the network interface name for restund to bind to if you have more than one network interface
-   ## If unset, defaults to the ansible_default_ipv4 (if defined) otherwise to eth0
-   restund_network_interface = eth0
-
-(see
-`defaults/main.yml <https://github.com/wireapp/ansible-restund/blob/master/defaults/main.yml>`__
-for a full list of variables to change if necessary)
-
-- Place a copy of the PEM formatted certificate and key you are going
-  to use for TLS communication to the restund server in
-  ``/tmp/tls_cert_and_priv_key.pem``. Remove it after you have
-  completed deploying restund with ansible.
-
-Install restund:
-
-::
-
-   ansible-playbook -i hosts.ini restund.yml -vv
 
 IMPORTANT checks
 ^^^^^^^^^^^^^^^^

--- a/src/how-to/install/ansible-VMs.rst
+++ b/src/how-to/install/ansible-VMs.rst
@@ -226,7 +226,7 @@ this step.
 Restund
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For instructions on how to install Restund, see :ref:`this page <_install-restund>`.
+For instructions on how to install Restund, see :ref:`this page <install-restund>`.
 
 
 IMPORTANT checks

--- a/src/how-to/install/index.rst
+++ b/src/how-to/install/index.rst
@@ -18,6 +18,7 @@ Installing wire-server
    (production) How to see centralized logs for wire-server <logging.rst>
    (production) Other configuration options <configuration-options.rst>
    sft
+   restund
    configure-federation
    Managing authentication with ansible <ansible-authentication.rst>
    Using tinc <ansible-tinc.rst>

--- a/src/how-to/install/restund.rst
+++ b/src/how-to/install/restund.rst
@@ -85,8 +85,4 @@ The private subnets only need to override the RFC-defined private networks, whic
 * Etc...
 
 
-looks good, but we need to mention something about private subnets needing to only override the RFC defined private networks, which we firewall off by default. (etc)
-
-
-
 

--- a/src/how-to/install/restund.rst
+++ b/src/how-to/install/restund.rst
@@ -63,7 +63,9 @@ For information on setting up and using ansible-playbook to install Wire compone
 Private Subnets
 ---------------
 
-If you need to enable Restund to connect to the outside, you can specify a list of private subnets in `CIDR format <https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing>`__ .
+By default, Restund is configured with a firewall that filters-out CIDR networks.
+
+If you need to enable Restund to connect to the outside, you can specify a list of private subnets in `CIDR format <https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing>`__, which will override Restund's firewall's default settings of filtering-out CIDR networks.
 
 You do this by setting the ``restund_allowed_private_network_cidrs`` option of the ``[restund:vars]`` section of the ansible inventory file (`for example this file <https://github.com/wireapp/wire-server-deploy/blob/master/ansible/inventory/prod/hosts.example.ini#L72>`__):
 
@@ -75,7 +77,7 @@ You do this by setting the ``restund_allowed_private_network_cidrs`` option of t
     # restund_network_interface = eth0
     restund_allowed_private_network_cidrs=192.168.0.1/32
 
-This is needed, for example, to allow talking to the logging server if it is on a separate network.
+This is needed, for example, to allow talking to the logging server if it is on a separate network: 
 
 The private subnets only need to override the RFC-defined private networks, which Wire firewalls off by default:
 

--- a/src/how-to/install/restund.rst
+++ b/src/how-to/install/restund.rst
@@ -58,7 +58,7 @@ To Install Restund, do the following:
 
    ansible-playbook -i hosts.ini restund.yml -vv
 
-For information on setting up and using ansible-playbook to install Wire components, see :ref:`this page <_ansible_vms>`.
+For information on setting up and using ansible-playbook to install Wire components, see :ref:`this page <ansible_vms>`.
 
 Private Subnets
 ---------------

--- a/src/how-to/install/restund.rst
+++ b/src/how-to/install/restund.rst
@@ -65,7 +65,7 @@ Private Subnets
 
 By default, Restund is configured with a firewall that filters-out CIDR networks.
 
-If you need to enable Restund to connect to the outside, you can specify a list of private subnets in `CIDR format <https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing>`__, which will override Restund's firewall's default settings of filtering-out CIDR networks.
+If you need to enable Restund to connect to a CIDR addressed host or network, you can specify a list of private subnets in `CIDR format <https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing>`__, which will override Restund's firewall's default settings of filtering-out CIDR networks.
 
 You do this by setting the ``restund_allowed_private_network_cidrs`` option of the ``[restund:vars]`` section of the ansible inventory file (`for example this file <https://github.com/wireapp/wire-server-deploy/blob/master/ansible/inventory/prod/hosts.example.ini#L72>`__):
 
@@ -85,6 +85,4 @@ The private subnets only need to override the RFC-defined private networks, whic
 * 10.x.x.x
 * 172.16.x.x - 172.31.x.x 
 * Etc...
-
-
 

--- a/src/how-to/install/restund.rst
+++ b/src/how-to/install/restund.rst
@@ -1,0 +1,82 @@
+.. _install-restund:
+
+Installing Restund
+==================
+
+Background
+~~~~~~~~~~
+
+Restund servers allow two users on different networks to have a Wire audio or video call.
+
+Please refer to the following :ref:`section to better understand Restund and how it works <understand-restund>`.
+
+Installation instructions
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To Install Restund, do the following:
+
+
+1. In your ``hosts.ini`` file, in the ``[restund:vars]`` section, set
+   the ``restund_network_interface`` to the name of the interface
+   you want restund to talk to clients on. This value defaults to the
+   ``default_ipv4_address``, with a fallback to ``eth0``.
+
+2. (optional) ``restund_peer_udp_advertise_addr=Y.Y.Y.Y``: set this to
+   the IP to advertise for other restund servers if different than the
+   ip on the 'restund_network_interface'. If using
+   'restund_peer_udp_advertise_addr', make sure that UDP (!) traffic
+   from any restund server (including itself) can reach that IP (for
+   ``restund <-> restund`` communication). This should only be necessary
+   if you're installing restund on a VM that is reachable on a public IP
+   address but the process cannot bind to that public IP address
+   directly (e.g. on AWS VPC VM). If unset, ``restund <-> restund`` UDP
+   traffic will default to the IP in the ``restund_network_interface``.
+
+.. code:: ini
+
+   [all]
+   (...)
+   restund01         ansible_host=X.X.X.X
+
+   (...)
+
+   [all:vars]
+   ## Set the network interface name for restund to bind to if you have more than one network interface
+   ## If unset, defaults to the ansible_default_ipv4 (if defined) otherwise to eth0
+   restund_network_interface = eth0
+
+   (see `defaults/main.yml <https://github.com/wireapp/ansible-restund/blob/master/defaults/main.yml>`__ for a full list of variables to change if necessary)
+
+3. Place a copy of the PEM formatted certificate and key you are going
+   to use for TLS communication to the restund server in
+   ``/tmp/tls_cert_and_priv_key.pem``. Remove it after you have
+   completed deploying restund with ansible.
+
+4. Use Ansible to actually install using the restund playbook:
+
+.. code:: bash
+
+   ansible-playbook -i hosts.ini restund.yml -vv
+
+For information on setting up and using ansible-playbook to install Wire components, see :ref:`this page <_ansible_vms>`.
+
+Private Subnets
+---------------
+
+If you need to enable Restund to connect to the outside, you can specify a list of private subnets in `CIDR format <https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing>`__ .
+
+You do this by setting the ``restund_allowed_private_network_cidrs`` option of the ``[restund:vars]`` section of the ansible inventory file (`for example this file <https://github.com/wireapp/wire-server-deploy/blob/master/ansible/inventory/prod/hosts.example.ini#L72>`__):
+
+.. code:: ini
+
+    [restund:vars]
+    ## Set the network interface name for restund to bind to if you have more than one network interface
+    ## If unset, defaults to the ansible_default_ipv4 (if defined) otherwise to eth0
+    # restund_network_interface = eth0
+    restund_allowed_private_network_cidrs=192.168.0.1/32
+
+This is needed, for example, to allow talking to the logging server if it is on a separate network.
+
+
+
+

--- a/src/how-to/install/restund.rst
+++ b/src/how-to/install/restund.rst
@@ -77,6 +77,16 @@ You do this by setting the ``restund_allowed_private_network_cidrs`` option of t
 
 This is needed, for example, to allow talking to the logging server if it is on a separate network.
 
+The private subnets only need to override the RFC-defined private networks, which Wire firewalls off by default:
+
+* 192.168.x.x
+* 10.x.x.x
+* 172.16.x.x - 172.31.x.x 
+* Etc...
+
+
+looks good, but we need to mention something about private subnets needing to only override the RFC defined private networks, which we firewall off by default. (etc)
+
 
 
 


### PR DESCRIPTION
As per JCT-72, moving Restund installation instructions into their own page, like SFT has.
Need to still leave a link to these instructions in the place these instrucitons are currently located.

## Checklist:

Please tick the following before making your PR:

* [x] I ran `make` on this branch to build the docs and there are **no WARNINGs**.
* [x] After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.
