### PR TITLE
Add release notes for 2.117.0 and 2.118.0

### DIFF
--- a/src/release-notes.rst
+++ b/src/release-notes.rst
@@ -26,6 +26,80 @@ specific operations.
 
 The following helm chart versions have been published since then:
 
+Chart Release 2.118.0
+=====================
+
+Upstream release notes: https://github.com/wireapp/wire-server/blob/develop/CHANGELOG.md#2021-11-15
+
+Release Notes
+-------------
+
+Release notes
+~~~~~~~~~~~~~
+
+-  In case you use a multi-datacentre cassandra setup (most likely you
+   do not), be aware that now
+   `LOCAL_QUORUM <https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html>`__
+   is in use as a default. (#1884)
+-  Deploy galley before brig. (#1857)
+-  Upgrade webapp version to 2021-11-01-production.0-v0.28.29-0-d919633
+   (#1856)
+
+API changes
+~~~~~~~~~~~
+
+-  Remove locale from publicly facing user profiles (but not from the
+   self profile) (#1888)
+
+Features
+~~~~~~~~
+
+-  End-points for configuring self-deleting messages. (#1857)
+
+Bug fixes and other updates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Ensure that all endpoints have a correct handler in prometheus
+   metrics (#1919)
+-  Push events when AppLock or SelfDeletingMessages config change.
+   (#1901)
+
+Documentation
+~~~~~~~~~~~~~
+
+-  Federation: Document how to deploy local builds (#1880)
+
+Internal changes
+~~~~~~~~~~~~~~~~
+
+-  Add a 'filterNodesByDatacentre' config option useful during cassandra
+   DC migration (#1886)
+-  Add ormolu to the direnv, add a GH Action to ensure formatting
+   (#1908)
+-  Turn placeholder access effects into actual Polysemy effects. (#1904)
+-  Fix a bug in the IdP.Mem interpreter, and added law tests for IdP
+   (#1863)
+-  Introduce fine-grained error types and polysemy error effects in
+   Galley. (#1907)
+-  Add polysemy store effects and split off Cassandra specific
+   functionality from the Galley.Data module hierarchy (#1890, #1906).
+   (#1890)
+-  Make golden-tests in wire-api package a separate test suite (for
+   faster feedback loop during development). (#1926)
+-  Separate IdPRawMetadataStore effect from IdP effect (#1924)
+-  Test sending message to multiple remote domains (#1899)
+-  Use cabal to build wire-server (opt-in) (#1853)
+
+Federation changes
+~~~~~~~~~~~~~~~~~~
+
+-  Close GRPC client after making a request to a federator. (#1865)
+-  Do not fail user deletion when a remote notification fails (#1912)
+-  Add a one-to-one conversation test in getting conversations in the
+   federation API (#1899)
+-  Notify remote participants when a user leaves a conversation because
+   they were deleted (#1891)
+
 Chart Release 2.117.0
 =====================
 

--- a/src/release-notes.rst
+++ b/src/release-notes.rst
@@ -26,8 +26,106 @@ specific operations.
 
 The following helm chart versions have been published since then:
 
+Chart Release 2.117.0
+=====================
 
+Upstream release notes: https://github.com/wireapp/wire-server/blob/develop/CHANGELOG.md#2021-10-29
 
+Release Notes
+-------------
+
+Release notes
+~~~~~~~~~~~~~
+
+-  Upgrade SFT to 2.1.15 (#1849)
+-  Upgrade team settings to Release:
+   `v4.2.0 <https://github.com/wireapp/wire-team-settings/releases/tag/v4.2.0>`__
+   and image tag: 4.2.0-v0.28.28-1e2ef7 (#1856)
+-  Upgrade Webapp to image tag: 20021-10-28-federation-m1 (#1856)
+
+API changes
+~~~~~~~~~~~
+
+-  Remove ``POST /list-conversations`` endpoint. (#1840)
+-  The member.self ID in conversation endpoints is qualified and
+   available as "qualified_id". The old unqualified "id" is still
+   available. (#1866)
+
+Features
+~~~~~~~~
+
+-  Allow configuring nginz so it serve the deeplink for apps to discover
+   the backend (#1889)
+-  SFT: allow using TURN discovery using 'turnDiscoveryEnabled' (#1519)
+
+Bug fixes and other updates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Fix an issue related to installing the SFT helm chart as a sub chart
+   to the wire-server chart. (#1677)
+-  SAML columns (Issuer, NameID) in CSV files with team members. (#1828)
+
+Internal changes
+~~~~~~~~~~~~~~~~
+
+-  Add a 'make flake-PATTERN' target to run a subset of tests multiple
+   times to trigger a failure case in flaky tests (#1875)
+-  Avoid a flaky test to fail related to phone updates and improve
+   failure output. (#1874)
+-  Brig: Delete deprecated ``GET /i/users/connections-status`` endpoint.
+   (#1842)
+-  Replace shell.nix with direnv + nixpkgs.buildEnv based setup (#1876)
+-  Make connection DB functions work with Qualified IDs (#1819)
+-  Fix more Swagger validation errors. (#1841)
+-  Turn ``Galley`` into a polysemy monad stack. (#1881)
+-  Internal CI tooling improvement: decrease integration setup time by
+   using helmfile. (#1805)
+-  Depend on hs-certificate master instead of our fork (#1822)
+-  Add internal endpoint to insert or update a 1-1 conversation. This is
+   to be used by brig when updating the status of a connection. (#1825)
+-  Update helm to 3.6.3 in developer tooling (nix-shell) (#1862)
+-  Improve the ``Qualified`` abstraction and make local/remote tagging
+   safer (#1839)
+-  Add some new Spar effects, completely isolating us from saml2-web-sso
+   interface (#1827)
+-  Convert legacy POST conversations/:cnv/members endpoint to Servant
+   (#1838)
+-  Simplify mock federator interface by removing unnecessary arguments.
+   (#1870)
+-  Replace the ``Spar`` newtype, instead using ``Sem`` directly. (#1833)
+
+Federation changes
+~~~~~~~~~~~~~~~~~~
+
+-  Remove remote guests as well as local ones when "Guests and services"
+   is disabled in a group conversation, and propagate removal to remote
+   members. (#1854)
+-  Check connections when adding remote users to a local conversation
+   and local users to remote conversations. (#1842)
+-  Check connections when creating group and team conversations with
+   remote members. (#1870)
+-  Server certificates without the "serverAuth" extended usage flag are
+   now rejected when connecting to a remote federator. (#1855)
+-  Close GRPC client after making a request to a remote federator.
+   (#1865)
+-  Support deleting conversations with federated users (#1861)
+-  Ensure that the conversation creator is included only once in
+   notifications sent to remote users (#1879)
+-  Allow connecting to remote users. One to one conversations are not
+   created yet. (#1824)
+-  Make federator's default log level Info (#1882)
+-  The creator of a conversation now appears as a member when the
+   conversation is fetched from a remote backend (#1842)
+-  Include remote connections in the response to
+   ``POST /list-connections`` (#1826)
+-  When a user gets deleted, notify remotes about conversations and
+   connections in chunks of 1000 (#1872, #1883)
+-  Make federated requests to multiple backends in parallel. (#1860)
+-  Make conversation ID of ``RemoteConversation`` unqualified and move
+   it out of the metadata record. (#1839)
+-  Make the conversation creator field in the
+   ``on-conversation-created`` RPC unqualified. (#1858)
+-  Update One2One conversation when connection status changes (#1850)
 
 Chart Release 2.116.0
 =====================


### PR DESCRIPTION
(fill in your PR description)

## Checklist:

Please tick the following before making your PR:

* [ ] I ran `make` on this branch to build the docs and there are **no WARNINGs**.
  There were already these warnings:
   ```
  /tmp/tmpkcnfkwvb/4eac54450dadf167a8cddec34d503c362e6a86e3/src/release-notes.rst:125: WARNING: Title underline too short.

   Chat Release 2.111.0
   ============
   /tmp/tmpkcnfkwvb/4eac54450dadf167a8cddec34d503c362e6a86e3/src/release-notes.rst:125: WARNING: Title underline too short.

   Chat Release 2.111.0
   ============
   /tmp/tmpkcnfkwvb/fb87f2bf733dd886a83360d772aa6e2aed7c9d20/src/release-notes.rst:125: WARNING: Title underline too short.

   Chat Release 2.111.0
   ============
    /tmp/tmpkcnfkwvb/fb87f2bf733dd886a83360d772aa6e2aed7c9d20/src/release-notes.rst:125: WARNING: Title underline too short.

   Chat Release 2.111.0
   ============
   ```
* [x] After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.
