### PR TITLE
Document cargohold federation domain option

### DIFF
--- a/src/how-to/install/configure-federation.rst
+++ b/src/how-to/install/configure-federation.rst
@@ -269,7 +269,7 @@ Configure helm charts: federator and ingress and webapp subcharts
 Set your chosen backend domain
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Read :ref:`choose-backend-domain` again, then set the backend domain two times
+Read :ref:`choose-backend-domain` again, then set the backend domain three times
 to the same value in the subcharts cargohold, galley and brig. You also need to
 set ``enableFederator`` to ``true``.
 

--- a/src/how-to/install/configure-federation.rst
+++ b/src/how-to/install/configure-federation.rst
@@ -269,8 +269,9 @@ Configure helm charts: federator and ingress and webapp subcharts
 Set your chosen backend domain
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Read :ref:`choose-backend-domain` again, then set the backend domain two times to the same value in the two subcharts
-galley and brig. You also need to set ``enableFederator`` to ``true``.
+Read :ref:`choose-backend-domain` again, then set the backend domain two times
+to the same value in the subcharts cargohold, galley and brig. You also need to
+set ``enableFederator`` to ``true``.
 
 .. code:: yaml
 
@@ -287,6 +288,12 @@ galley and brig. You also need to set ``enableFederator`` to ``true``.
         enableFederator: true
         optSettings:
           setFederationDomain: example.com # your chosen "backend domain"
+
+    cargohold:
+      config:
+        enableFederator: true
+        optSettings:
+          federationDomain: example.com # your chosen "backend domain"
 
 Configure the webapp to enable federation and set your chosen backend domain one more time
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/how-to/install/configure-federation.rst
+++ b/src/how-to/install/configure-federation.rst
@@ -292,7 +292,7 @@ set ``enableFederator`` to ``true``.
     cargohold:
       config:
         enableFederator: true
-        optSettings:
+        settings:
           federationDomain: example.com # your chosen "backend domain"
 
 Configure the webapp to enable federation and set your chosen backend domain one more time


### PR DESCRIPTION
Document new mandatory `federationDomain` setting for cargohold, introduced by https://github.com/wireapp/wire-server/pull/1990.

## Checklist:

Please tick the following before making your PR:

* [x] I ran `make` on this branch to build the docs and there are **no WARNINGs**.
* [x] After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.
