### PR TITLE
Pin nix docker image version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nixos/nix AS builder
+FROM nixos/nix:2.3.12 AS builder
 
 RUN set -e -x ;\
     apk add --no-cache bash git


### PR DESCRIPTION
Upstream has updated the nix docker image to nix 2.5, which is now no longer based on Alpine Linux. The new version of the image seems to be completely broken (building and installing derivations doesn't work at all), so I've pinned the image we build the docker image from to the last known good version, 2.3.12.

## Checklist:

Please tick the following before making your PR:

* [x] I ran `make` on this branch to build the docs and there are **no WARNINGs**.
* [x] After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.
