### PR TITLE
Fix federation allow list examples

### DIFF
--- a/src/how-to/install/configure-federation.rst
+++ b/src/how-to/install/configure-federation.rst
@@ -357,9 +357,10 @@ By default, federation is turned off (allow list set to the empty list):
     # override values for wire-server
     # (e.g. under ./helm_vars/wire-server/values.yaml)
     federator:
-      optSettings:
-        federationStrategy:
-          allowedDomains: []
+      config:
+        optSettings:
+          federationStrategy:
+            allowedDomains: []
 
 You can choose to federate with a specific list of allowed backends:
 
@@ -368,11 +369,12 @@ You can choose to federate with a specific list of allowed backends:
     # override values for wire-server
     # (e.g. under ./helm_vars/wire-server/values.yaml)
     federator:
-      optSettings:
-        federationStrategy:
-          allowedDomains:
-           - example.com
-           - example.org
+      config:
+        optSettings:
+          federationStrategy:
+            allowedDomains:
+             - example.com
+             - example.org
 
 Alternatively, you can federate with everyone:
 
@@ -381,9 +383,10 @@ Alternatively, you can federate with everyone:
     # override values for wire-server
     # (e.g. under ./helm_vars/wire-server/values.yaml)
     federator:
-      optSettings:
-        federationStrategy:
-          allowAll: true
+      config:
+        optSettings:
+          federationStrategy:
+            allowAll: true
 
 
 Applying all configuration changes


### PR DESCRIPTION


## Checklist:

Please tick the following before making your PR:

* [x] I ran `make` on this branch to build the docs and there are **no WARNINGs** *that belong to this PR*.
* [x] After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.

WARNINGs when this branch is built with `make html`:
```
sphinx-build -M html "/home/sven/src/wire-docs/src" "/home/sven/src/wire-docs/build" -q
/nix/store/brp9dz5v47zxwkskffy57pzf8fmng2rm-python3-3.8.8-env/lib/python3.8/site-packages/recommonmark/parser.py:75: UserWarning: Container node skipped: type=document
  warn("Container node skipped: type={0}".format(mdnode.t))
sphinx-multiversion "/home/sven/src/wire-docs/src" "/home/sven/src/wire-docs/build/html" -q
/nix/store/brp9dz5v47zxwkskffy57pzf8fmng2rm-python3-3.8.8-env/lib/python3.8/site-packages/rst2pdf/rson.py:119: FutureWarning: Possible nested set at position 2
  splitter = re.compile(pattern).split
/nix/store/brp9dz5v47zxwkskffy57pzf8fmng2rm-python3-3.8.8-env/lib/python3.8/site-packages/rst2pdf/rson.py:119: FutureWarning: Possible nested set at position 2
  splitter = re.compile(pattern).split
/tmp/tmpriqowg2r/4eac54450dadf167a8cddec34d503c362e6a86e3/src/release-notes.rst:125: WARNING: Title underline too short.

Chat Release 2.111.0
============
/tmp/tmpriqowg2r/4eac54450dadf167a8cddec34d503c362e6a86e3/src/release-notes.rst:125: WARNING: Title underline too short.

Chat Release 2.111.0
============
/nix/store/brp9dz5v47zxwkskffy57pzf8fmng2rm-python3-3.8.8-env/lib/python3.8/site-packages/rst2pdf/rson.py:119: FutureWarning: Possible nested set at position 2
  splitter = re.compile(pattern).split
/tmp/tmpriqowg2r/fb87f2bf733dd886a83360d772aa6e2aed7c9d20/src/release-notes.rst:125: WARNING: Title underline too short.

Chat Release 2.111.0
============
/tmp/tmpriqowg2r/fb87f2bf733dd886a83360d772aa6e2aed7c9d20/src/release-notes.rst:125: WARNING: Title underline too short.

Chat Release 2.111.0
============
```
