### PR TITLE
Fix internal reference link to "Backend domain"

### DIFF
--- a/src/understand/federation/api.rst
+++ b/src/understand/federation/api.rst
@@ -72,7 +72,7 @@ Between two federated backends, the components talk to each other via the
 When making the call to the `Federator`, the components use HTTP2. They call
 the ``Outward`` service, which accepts ``POST`` requests with path
 ``/rpc/:domain/:component/:rpc``. Such a request will be forwarded to a remote
-federator with the given :ref:`Backend domain <Backend domains>`, and converted
+federator with the given :ref:`Backend domain <Backend-domains>`, and converted
 to the appropriate request for its ``Inward`` service.
 
 .. _api-from-federator-to-components:


### PR DESCRIPTION
This PR removes the currently existing warning, when generating the rendered output

## Checklist:

Please tick the following before making your PR:

* [x] I ran `make` on this branch to build the docs and there are **no WARNINGs**.
* [x] After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.
