### PR TITLE
Fix links in RADME.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Visit https://docs.wire.com/
 The structure of this document has been heavily inspired by [this blog
 post](https://www.divio.com/blog/documentation/).
 
-We use [sphinx](https://sphinx-doc.org/) for rendering documentation.
+We use [sphinx](https://www.sphinx-doc.org/) for rendering documentation.
 
 Most documentation is written in RestructuredText (with `.rst` file extension).
 The reason for that is A) the default support from sphinx and B) some of the

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ etc.
 
 For dealing with RST, here are some resources:
 
-* here is a [cheat sheet](https://docutils.sourceforge.net/docs/user/rst/quickref.html)
-* [here is another one](https://docutils.sourceforge.net/docs/user/rst/cheatsheet.html).
+* here is a [cheat sheet](https://docutils.sourceforge.io/docs/user/rst/quickref.html)
+* [here is another one](https://docutils.sourceforge.io/docs/user/rst/cheatsheet.html).
 * And [another one](https://sublime-and-sphinx-guide.readthedocs.io/en/latest/references.html).
 
 At the popular request, there is now also some support for markdown files (`.md` file


### PR DESCRIPTION
This PR will correct links in README.md, which were pointing to no longer working targets

## Checklist:

Please tick the following before making your PR:

* [x] I ran `make` on this branch to build the docs and there are **no WARNINGs**.
* [x] After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.
