### PR TITLE
Fix: removed outdated date reference

### DIFF
--- a/src/index.rst
+++ b/src/index.rst
@@ -6,7 +6,7 @@
 Welcome to Wire's (self-hosting) documentation!
 ===============================================
 
-The targeted audience of this documentation is (currently, as of July 2019):
+The targeted audience of this documentation is:
 
 * people wanting to understand how the server components of Wire work
 * people wishing to self-host Wire on their own datacentres or cloud


### PR DESCRIPTION
I think that the state of the current documentation is self-evident, no need to mention a specific date that the state refers to

## Checklist:

Please tick the following before making your PR:

* [ ] I ran `make` on this branch to build the docs and there are **no WARNINGs**.
* [ ] After running `make`, I looked at the output by opening build/html/index.html in a browser and I'm satisfied with the rendering.
--- 

I tried to execute the step from the checklist, but I could not get 'sphinx' to work on my Windows WLS environment. I gave up after 20 minutes, I believe this is a small change that does not warrant this effort, but feel free to say otherwise if you disagree.