### PR TITLE
docs(docs.wire.com): WPB-15365 fix the release to enable OIDC token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
-      contents: write 
+      contents: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
### Change type
<!-- choose the kind of change this PR introduces -->

* [ ] Documentation change
* [x] Build pipeline change
* [ ] Submodule update
* [ ] Deployment change

### Basic information 

* [x] THIS CHANGE REQUIRES A WIRE-DOCS RELEASE NOW

### Testing

* [ ] I ran/applied the changes myself, in a test environment.

### Tracking

* [ ] I mentioned this PR in Jira, OR I mentioned the Jira ticket in this PR.
* [x] I mentioned this PR in one of the issues attached to one of our repositories.
